### PR TITLE
Naive implementation of MulMod

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -679,6 +679,22 @@ func (z *Int) Smod(x, y *Int) *Int {
 	return z
 }
 
+// MulMod calculates the modulo-n multiplication of x and y and
+// returns z
+func (z *Int) MulMod(x, y, m *Int) *Int {
+	// xm := NewInt().Mod(x, m)
+	// ym := NewInt().Mod(y, m)
+	bx := big.NewInt(0)
+	by := big.NewInt(0)
+	bm := big.NewInt(0)
+	bx.SetBytes(x.Bytes()[:])
+	by.SetBytes(y.Bytes()[:])
+	bm.SetBytes(m.Bytes()[:])
+	zm := big.NewInt(0).Mul(bx, by)
+	z.SetFromBig(big.NewInt(0).Mod(zm, bm))
+	return z
+}
+
 // Abs interprets x as a a signed number, and sets z to the Abs value
 //   S256(0)        = 0
 //   S256(1)        = 1

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -197,6 +197,40 @@ func TestRandomSMod(t *testing.T) {
 	)
 }
 
+func TestRandomMulMod(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		b1, f1, err := randNums()
+		if err != nil {
+			t.Fatalf("Error getting a random number: %v", err)
+		}
+
+		b2, f2, err := randNums()
+		if err != nil {
+			t.Fatalf("Error getting a random number: %v", err)
+		}
+
+		b3, f3, err := randNums()
+		if err != nil {
+			t.Fatalf("Error getting a random number: %v", err)
+		}
+
+		b4, f4, err := randNums()
+		for b4.Cmp(big.NewInt(0)) == 0 {
+			b4, f4, err = randNums()
+			if err != nil {
+				t.Fatalf("Error getting a random number: %v", err)
+			}
+		}
+
+		f1.MulMod(f2, f3, f4)
+		b1.Mod(big.NewInt(0).Mul(b2, b3), b4)
+
+		if !checkEq(b1, f1) {
+			t.Fatalf("Expected equality:\nf2= %v\nf3= %v\nf4= %v\n[ op ]==\nf = %v\nb = %x\n", f2.Hex(), f3.Hex(), f4.Hex(), f1.Hex(), b1)
+		}
+	}
+}
+
 var bigtt255 = bigPow(2, 255)
 
 func S256(x *big.Int) *big.Int {


### PR DESCRIPTION
The biggest performance blocker is that there is a need to use `big.Int` because of the overflow. A trick could be to implement basic u512 support for multiplication operations for `Mul`.