### PR TITLE
Implement fmt.Formatter interface

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -1352,3 +1352,9 @@ func (z *Int) SignExtend(back, num *Int) {
 	}
 
 }
+
+var _ fmt.Formatter = zero
+
+func (z *Int) Format(s fmt.State, ch rune) {
+	z.ToBig().Format(s, ch)
+}


### PR DESCRIPTION
It uses ToBig conversion but as I expect the use of it will be mostly for
debugging, so it shouldn't be a problem.