### PR TITLE
Add "full" 256x256->512 multiplication

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -269,6 +269,24 @@ func (z *Int) Sub(x, y *Int) {
 	z.SubOverflow(x, y) // Inlined.
 }
 
+// umul computes full 256 x 256 -> 512 multiplication.
+func umul(x, y *Int) [8]uint64 {
+	var res [8]uint64
+	for j := 0; j < len(y); j++ {
+		var carry uint64
+		for i := 0; i < len(x); i++ {
+			var p [2]uint64
+			p[1], p[0] = bits.Mul64(x[i], y[j])
+			addTo128(p[:], res[i+j], 0)
+			addTo128(p[:], carry, 0)
+			res[i+j] = p[0]
+			carry = p[1]
+		}
+		res[j+len(x)] = carry
+	}
+	return res
+}
+
 // Mul sets z to the sum x*y
 func (z *Int) Mul(x, y *Int) {
 

--- a/uint256.go
+++ b/uint256.go
@@ -284,10 +284,11 @@ func umul(x, y *Int) [8]uint64 {
 	var res [8]uint64
 	for j := 0; j < len(y); j++ {
 		var carry uint64
-		for i := 0; i < len(x); i++ {
-			res[i+j], carry = umulStep(res[i+j], x[i], y[j], carry)
-		}
-		res[j+len(x)] = carry
+		res[j+0], carry = umulStep(res[j+0], x[0], y[j], carry)
+		res[j+1], carry = umulStep(res[j+1], x[1], y[j], carry)
+		res[j+2], carry = umulStep(res[j+2], x[2], y[j], carry)
+		res[j+3], carry = umulStep(res[j+3], x[3], y[j], carry)
+		res[j+4] = carry
 	}
 	return res
 }

--- a/uint256.go
+++ b/uint256.go
@@ -220,10 +220,10 @@ func (z *Int) AddMod(x, y, m *Int) {
 }
 
 // addMiddle128 adds two uint64 integers to the upper part of z
-func (z *Int) addHigh128(x, y uint64) {
+func addTo128(z []uint64, x0, x1 uint64) {
 	var carry uint64
-	z[2], carry = bits.Add64(z[2], y, carry) // TODO: The order of adding x, y is confusing.
-	z[3], _ = bits.Add64(z[3], x, carry)
+	z[0], carry = bits.Add64(z[0], x0, carry) // TODO: The order of adding x, y is confusing.
+	z[1], _ = bits.Add64(z[1], x1, carry)
 }
 
 // PaddedBytes encodes a Int as a 0-padded byte slice. The length
@@ -325,10 +325,10 @@ func (z *Int) Mul(x, y *Int) {
 	alfa.Add(alfa, beta)
 
 	beta[3], beta[2] = bits.Mul64(x[1], y[1])
-	alfa.addHigh128(beta[3], beta[2])
+	addTo128(alfa[2:], beta[2], beta[3])
 
 	beta[3], beta[2] = bits.Mul64(x[2], y[0])
-	alfa.addHigh128(beta[3], beta[2])
+	addTo128(alfa[2:], beta[2], beta[3])
 	z.Copy(alfa)
 }
 
@@ -355,7 +355,7 @@ func (z *Int) Squared() {
 
 	// c * c
 	beta[3], beta[2] = bits.Mul64(z[1], z[1])
-	alfa.addHigh128(beta[3], beta[2])
+	addTo128(alfa[2:], beta[2], beta[3])
 	z.Copy(alfa)
 }
 
@@ -1160,8 +1160,8 @@ func (z *Int) Exp(base, exponent *Int) *Int {
 		return z.Copy(base)
 	}
 	var (
-		word uint64
-		bits int
+		word       uint64
+		bits       int
 		multiplier = *base
 	)
 	expBitlen := exponent.BitLen()

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -614,34 +614,14 @@ func TestFixed256bit_Sub(t *testing.T) {
 func TestFixed256bit_Mul(t *testing.T) {
 
 	b1 := big.NewInt(0).SetBytes(hex2Bytes("00000000000000000000000000000000000000000002a3f8ba829e365f479526"))
-	b2 := big.NewInt(0).SetBytes(hex2Bytes("0000000000000000000000000000000000000000000000000000000000000001"))
+	b2 := big.NewInt(0).SetBytes(hex2Bytes("0000000000000000000000000000000000000000000000000000000000000002"))
 
-	/*
-		f1= 0000000000000000.0000000000000000.000000000003e6da.5c61238a298b16ec
-		f2= 0000000000000000.0000000000000000.0000000000000000.000000000000206c
-		[ * ]==
-		f = 1d6c3e387e80a3f8.0000000000000bb3.1d6c3e387e80afab.1d6c437ae98b2b90
-		bf= 0000000000000000.0000000000000000.000000007e80afab.1d6c437ae98b2b90
-		b = 7e80afab1d6c437ae98b2b90
-
-	*/
-
-	f, _ := FromBig(b1)
+	f1, _ := FromBig(b1)
 	f2, _ := FromBig(b2)
 
-	fmt.Printf("B1   : %x\n", b1)
-	fmt.Printf("B2   : %x\n", b2)
-	fmt.Printf("F1   : %s\n", f.Hex())
-	fmt.Printf("F2   : %s\n", f2.Hex())
-	fmt.Println("--")
 	b1.Mul(b1, b2)
-	f.Mul(f, f2)
-	fmt.Printf("B   : %x\n", b1)
-	fmt.Printf("F   : %s\n", f.Hex())
-
-	res, _ := FromBig(b1)
-	fmt.Printf("b->f: %s\n", res.Hex())
-	fmt.Printf("EQ  : %v\n", f.Eq(res))
+	f1.Mul(f1, f2)
+	requireEq(t, b1, f1, "")
 }
 
 func TestFixed256bit_Div(t *testing.T) {


### PR DESCRIPTION
This is used for `MulMod()` so `big.Mul()` is not needed any more (we still need `big.Mod()`).
This makes `small/uint256-6` case slower because we also removed the shortcut for `128x128` case.
The same procedure can be used to implement `Mul()`, but when `umul()` is used directly the final result is slower - optimizer is not clever enough to notice that the top 4 words in `umul()` are not used in the end.
Inner loop unroll removes any bounds checking.
```
name                     old time/op  new time/op  delta
_MulMod/large/big-6       384ns ± 1%   382ns ± 0%   -0.47%  (p=0.048 n=5+5)
_MulMod/large/uint256-6   802ns ± 0%   721ns ± 0%  -10.05%  (p=0.000 n=5+4)
_MulMod/small/big-6      93.9ns ± 0%  93.6ns ± 0%     ~     (p=0.103 n=5+5)
_MulMod/small/uint256-6  33.5ns ± 0%  41.1ns ± 0%  +22.69%  (p=0.016 n=4+5)
```