### PR TITLE
Faster and fixed big.Int -> uint256.Int conversion

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,28 @@
 version: 2.1
 
+commands:
+  test:
+    parameters:
+      arch:
+        default: "amd64"
+        description: The target architecture.
+        type: enum
+        enum: ["amd64", "386"]
+    steps:
+      - run:
+          name: "Test (<<parameters.arch>>)"
+          command: |
+            export GOARCH=<<parameters.arch>>
+            go version
+            go env
+            go test -v
+
 jobs:
 
   linux:
     docker:
       - image: cimg/go:1.14
     steps:
-      - run:
-          name: "Go version"
-          command: |
-            go version
-            go env
       - run:
           name: "Install tools"
           command: |
@@ -19,9 +31,10 @@ jobs:
       - run:
           name: "Lint"
           command: golangci-lint run
-      - run:
-          name: "Test"
-          command: go test -v
+      - test:
+          arch: "amd64"
+      - test:
+          arch: "386"
       - run:
           name: "Benchmark"
           command: go test -run=- -bench=. -benchmem

--- a/conversion.go
+++ b/conversion.go
@@ -13,48 +13,48 @@ import (
 )
 
 const (
-	u256_nWords = 256 / bits.UintSize // number of Words in 256-bit
+	maxWords = 256 / bits.UintSize // number of big.Words in 256-bit
 )
 
-// NewFromBig is a platform-independent implementation of MarshallBigInt
+// NewFromBig creates new Int from big.Int.
 func NewFromBig(b *big.Int) (*Int, bool) {
-	fixed := &Int{}
-	overflow := fixed.SetFromBig(b)
-	return fixed, overflow
+	z := &Int{}
+	overflow := z.SetFromBig(b)
+	return z, overflow
 }
 
 // SetFromBig
 // TODO: finish implementation by adding 32-bit platform support,
 // ensure we have sufficient testing, esp for negative bigints
-func (fixed *Int) SetFromBig(b *big.Int) bool {
+func (z *Int) SetFromBig(b *big.Int) bool {
 	var overflow bool
-	fixed.Clear()
-	z := b.Bits()
-	numWords := len(z)
+	z.Clear()
+	words := b.Bits()
+	numWords := len(words)
 	if numWords == 0 {
 		return overflow
 	}
 	// If there's more than 64 bits, we can skip all higher words
-	// z consists of 64 or 32-bit words. So we only care about the last
+	// words consists of 64 or 32-bit words. So we only care about the last
 	// (or last two)
-	if numWords > u256_nWords {
-		z = z[:u256_nWords]
-		numWords = len(z)
+	if numWords > maxWords {
+		words = words[:maxWords]
+		numWords = len(words)
 		overflow = true
 	}
 	// Code below is for 64-bit platforms only (numWords: [1-4] )
-	fixed[0] = uint64(z[0])
+	z[0] = uint64(words[0])
 	if numWords > 1 {
-		fixed[1] = uint64(z[1])
+		z[1] = uint64(words[1])
 		if numWords > 2 {
-			fixed[2] = uint64(z[2])
+			z[2] = uint64(words[2])
 			if numWords > 3 {
-				fixed[3] = uint64(z[3])
+				z[3] = uint64(words[3])
 			}
 		}
 	}
 	if b.Sign() == -1 {
-		fixed.Neg()
+		z.Neg()
 	}
 	return overflow
 }

--- a/conversion.go
+++ b/conversion.go
@@ -31,18 +31,22 @@ func (z *Int) SetFromBig(b *big.Int) bool {
 	words := b.Bits()
 	overflow := len(words) > maxWords
 
-	// Code below is for 64-bit platforms only (len(words): [1-4])
-	if len(words) > 0 {
-		z[0] = uint64(words[0])
-		if len(words) > 1 {
-			z[1] = uint64(words[1])
-			if len(words) > 2 {
-				z[2] = uint64(words[2])
-				if len(words) > 3 {
-					z[3] = uint64(words[3])
+	switch maxWords { // Compile-time check.
+	case 4: // 64-bit architectures.
+		if len(words) > 0 {
+			z[0] = uint64(words[0])
+			if len(words) > 1 {
+				z[1] = uint64(words[1])
+				if len(words) > 2 {
+					z[2] = uint64(words[2])
+					if len(words) > 3 {
+						z[3] = uint64(words[3])
+					}
 				}
 			}
 		}
+	default:
+		panic("unsupported architecture")
 	}
 
 	if b.Sign() == -1 {

--- a/conversion.go
+++ b/conversion.go
@@ -23,9 +23,8 @@ func NewFromBig(b *big.Int) (*Int, bool) {
 	return z, overflow
 }
 
-// SetFromBig
-// TODO: finish implementation by adding 32-bit platform support,
-// ensure we have sufficient testing, esp for negative bigints
+// SetFromBig converts a big.Int to Int and sets the value to z.
+// TODO: Ensure we have sufficient testing, esp for negative bigints.
 func (z *Int) SetFromBig(b *big.Int) bool {
 	z.Clear()
 	words := b.Bits()
@@ -43,6 +42,18 @@ func (z *Int) SetFromBig(b *big.Int) bool {
 						z[3] = uint64(words[3])
 					}
 				}
+			}
+		}
+	case 8: // 32-bit architectures.
+		numWords := len(words)
+		if overflow {
+			numWords = maxWords
+		}
+		for i := 0; i < numWords; i++ {
+			if i%2 == 0 {
+				z[i/2] = uint64(words[i])
+			} else {
+				z[i/2] |= uint64(words[i]) << 32
 			}
 		}
 	default:

--- a/conversion.go
+++ b/conversion.go
@@ -27,32 +27,24 @@ func NewFromBig(b *big.Int) (*Int, bool) {
 // TODO: finish implementation by adding 32-bit platform support,
 // ensure we have sufficient testing, esp for negative bigints
 func (z *Int) SetFromBig(b *big.Int) bool {
-	var overflow bool
 	z.Clear()
 	words := b.Bits()
-	numWords := len(words)
-	if numWords == 0 {
-		return overflow
-	}
-	// If there's more than 64 bits, we can skip all higher words
-	// words consists of 64 or 32-bit words. So we only care about the last
-	// (or last two)
-	if numWords > maxWords {
-		words = words[:maxWords]
-		numWords = len(words)
-		overflow = true
-	}
-	// Code below is for 64-bit platforms only (numWords: [1-4] )
-	z[0] = uint64(words[0])
-	if numWords > 1 {
-		z[1] = uint64(words[1])
-		if numWords > 2 {
-			z[2] = uint64(words[2])
-			if numWords > 3 {
-				z[3] = uint64(words[3])
+	overflow := len(words) > maxWords
+
+	// Code below is for 64-bit platforms only (len(words): [1-4])
+	if len(words) > 0 {
+		z[0] = uint64(words[0])
+		if len(words) > 1 {
+			z[1] = uint64(words[1])
+			if len(words) > 2 {
+				z[2] = uint64(words[2])
+				if len(words) > 3 {
+					z[3] = uint64(words[3])
+				}
 			}
 		}
 	}
+
 	if b.Sign() == -1 {
 		z.Neg()
 	}

--- a/conversion.go
+++ b/conversion.go
@@ -19,14 +19,14 @@ const (
 // NewFromBig is a platform-independent implementation of MarshallBigInt
 func NewFromBig(b *big.Int) (*Int, bool) {
 	fixed := &Int{}
-	overflow := fixed.SetFromBigFast(b)
+	overflow := fixed.SetFromBig(b)
 	return fixed, overflow
 }
 
-// SetFromBigFast
+// SetFromBig
 // TODO: finish implementation by adding 32-bit platform support,
 // ensure we have sufficient testing, esp for negative bigints
-func (fixed *Int) SetFromBigFast(b *big.Int) bool {
+func (fixed *Int) SetFromBig(b *big.Int) bool {
 	var overflow bool
 	fixed.Clear()
 	z := b.Bits()

--- a/uint256.go
+++ b/uint256.go
@@ -61,15 +61,6 @@ func (z *Int) ToBig() *big.Int {
 	return x
 }
 
-// SetFromBig is a convenience-setter from big.Int. Not optimized for speed, mainly for easy testing
-func (z *Int) SetFromBig(int *big.Int) bool {
-	z.SetBytes(int.Bytes())
-	if int.Sign() == -1 {
-		z.Neg()
-	}
-	return int.BitLen() > 256
-}
-
 // SetBytes interprets buf as the bytes of a big-endian unsigned
 // integer, sets z to that value, and returns z.
 func (z *Int) SetBytes(buf []byte) *Int {

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -1320,6 +1320,31 @@ func Benchmark_SDiv(bench *testing.B) {
 	bench.Run("large/uint256", benchmark_SdivLarge_Bit)
 }
 
+func benchmarkSetFromBig(bench *testing.B, b *big.Int) Int {
+	var f Int
+	for i := 0; i < bench.N; i++ {
+		f.SetFromBig(b)
+	}
+	return f
+}
+
+func BenchmarkSetFromBig(bench *testing.B) {
+	param1 := big.NewInt(0xff)
+	bench.Run("1word", func(bench *testing.B) { benchmarkSetFromBig(bench, param1) })
+
+	param2 := new(big.Int).Lsh(param1, 64)
+	bench.Run("2words", func(bench *testing.B) { benchmarkSetFromBig(bench, param2) })
+
+	param3 := new(big.Int).Lsh(param2, 64)
+	bench.Run("3words", func(bench *testing.B) { benchmarkSetFromBig(bench, param3) })
+
+	param4 := new(big.Int).Lsh(param3, 64)
+	bench.Run("4words", func(bench *testing.B) { benchmarkSetFromBig(bench, param4) })
+
+	param5 := new(big.Int).Lsh(param4, 64)
+	bench.Run("overflow", func(bench *testing.B) { benchmarkSetFromBig(bench, param5) })
+}
+
 func TestByteRepresentation(t *testing.T) {
 
 	//0e320219838e859b2f9f18b72e3d4073ca50b37d


### PR DESCRIPTION
```
name                     old time/op  new time/op  delta
_Add/big-6               19.1ns ± 1%  19.0ns ± 0%     ~     (p=0.167 n=5+5)
_Add/uint256-6           2.99ns ± 0%  2.99ns ± 0%     ~     (all equal)
_Sub/big-6               19.0ns ± 0%  19.0ns ± 0%     ~     (all equal)
_Sub/uint256-6           2.99ns ± 0%  2.99ns ± 0%     ~     (all equal)
_Sub/uint256_of-6        1.82ns ± 0%  1.82ns ± 0%     ~     (all equal)
_Mul/big-6               88.9ns ± 0%  89.1ns ± 0%     ~     (p=0.135 n=5+5)
_Mul/uint256-6           15.5ns ± 0%  15.5ns ± 0%     ~     (all equal)
_Square/big-6            87.9ns ± 0%  87.9ns ± 1%     ~     (p=1.000 n=5+5)
_Square/uint256-6        16.0ns ± 0%  16.0ns ± 0%     ~     (all equal)
_And/big-6               12.4ns ± 0%  12.5ns ± 0%   +0.81%  (p=0.008 n=5+5)
_And/uint256-6           1.62ns ± 1%  1.61ns ± 0%     ~     (p=0.143 n=4+4)
_Or/big-6                14.9ns ± 0%  14.9ns ± 0%     ~     (all equal)
_Or/uint256-6            1.61ns ± 0%  1.60ns ± 0%   -0.47%  (p=0.000 n=5+4)
_Xor/big-6               15.8ns ± 0%  15.8ns ± 0%     ~     (p=0.556 n=5+4)
_Xor/uint256-6           1.60ns ± 0%  1.62ns ± 0%   +1.09%  (p=0.029 n=4+4)
_Cmp/big-6               5.97ns ± 0%  5.96ns ± 0%   -0.17%  (p=0.029 n=4+4)
_Cmp/uint256-6           3.41ns ± 0%  2.96ns ± 0%  -13.08%  (p=0.000 n=4+5)
_Lsh/big/n_eq_0-6        36.1ns ± 0%  36.0ns ± 0%     ~     (p=0.270 n=5+5)
_Lsh/big/n_gt_192-6      47.4ns ± 0%  47.4ns ± 0%     ~     (p=0.508 n=5+5)
_Lsh/big/n_gt_128-6      47.3ns ± 0%  47.3ns ± 0%     ~     (p=0.571 n=5+4)
_Lsh/big/n_gt_64-6       45.3ns ± 0%  45.4ns ± 0%     ~     (p=0.429 n=5+5)
_Lsh/big/n_gt_0-6        44.1ns ± 0%  44.2ns ± 0%     ~     (p=0.119 n=5+5)
_Lsh/uint256/n_eq_0-6    4.09ns ± 0%  4.09ns ± 0%     ~     (all equal)
_Lsh/uint256/n_gt_192-6  4.32ns ± 0%  4.32ns ± 0%     ~     (all equal)
_Lsh/uint256/n_gt_128-6  5.51ns ± 1%  5.57ns ± 3%     ~     (p=0.190 n=5+5)
_Lsh/uint256/n_gt_64-6   7.34ns ± 0%  7.31ns ± 0%   -0.41%  (p=0.029 n=4+4)
_Lsh/uint256/n_gt_0-6    8.15ns ± 0%  8.19ns ± 0%   +0.44%  (p=0.008 n=5+5)
_Rsh/big/n_eq_0-6        37.3ns ± 0%  37.6ns ± 0%   +0.64%  (p=0.008 n=5+5)
_Rsh/big/n_gt_192-6      29.8ns ± 0%  29.8ns ± 0%     ~     (p=1.000 n=5+5)
_Rsh/big/n_gt_128-6      38.5ns ± 0%  38.6ns ± 0%   +0.26%  (p=0.029 n=4+4)
_Rsh/big/n_gt_64-6       40.7ns ± 0%  41.0ns ± 0%   +0.74%  (p=0.016 n=5+5)
_Rsh/big/n_gt_0-6        41.8ns ± 0%  42.1ns ± 0%   +0.77%  (p=0.008 n=5+5)
_Rsh/uint256/n_eq_0-6    4.09ns ± 0%  4.09ns ± 0%     ~     (all equal)
_Rsh/uint256/n_gt_192-6  4.32ns ± 0%  4.32ns ± 0%     ~     (all equal)
_Rsh/uint256/n_gt_128-6  5.54ns ± 1%  5.56ns ± 0%     ~     (p=0.825 n=5+4)
_Rsh/uint256/n_gt_64-6   7.22ns ± 0%  7.23ns ± 0%   +0.14%  (p=0.008 n=5+5)
_Rsh/uint256/n_gt_0-6    8.06ns ± 0%  8.19ns ± 0%   +1.61%  (p=0.016 n=4+5)
_Exp/large/big-6         20.0µs ± 0%  20.2µs ± 0%   +1.10%  (p=0.008 n=5+5)
_Exp/large/uint256-6     6.74µs ± 0%  6.74µs ± 0%     ~     (p=0.159 n=5+5)
_Exp/small/big-6         5.91µs ± 0%  5.97µs ± 0%   +1.10%  (p=0.008 n=5+5)
_Exp/small/uint256-6      581ns ± 0%   581ns ± 0%     ~     (p=0.444 n=5+5)
_Div/large/big-6          245ns ± 0%   246ns ± 0%   +0.65%  (p=0.032 n=5+5)
_Div/large/uint256-6      190ns ± 0%   182ns ± 0%   -4.01%  (p=0.000 n=5+4)
_Div/small/big-6         68.6ns ± 0%  68.9ns ± 1%   +0.44%  (p=0.016 n=4+5)
_Div/small/uint256-6     13.0ns ± 0%  13.1ns ± 0%   +0.77%  (p=0.008 n=5+5)
_MulMod/large/big-6       382ns ± 0%   383ns ± 0%   +0.26%  (p=0.008 n=5+5)
_MulMod/large/uint256-6   720ns ± 0%   633ns ± 0%  -12.13%  (p=0.016 n=5+4)
_MulMod/small/big-6      94.1ns ± 0%  94.9ns ± 1%   +0.85%  (p=0.008 n=5+5)
_MulMod/small/uint256-6  41.1ns ± 0%  41.1ns ± 0%     ~     (p=0.556 n=4+5)
_Mod/large/big-6          142ns ± 0%   138ns ± 0%     ~     (p=0.079 n=4+5)
_Mod/large/uint256-6      146ns ± 0%   145ns ± 0%     ~     (p=0.079 n=4+5)
_Mod/small/big-6         40.9ns ± 0%  42.3ns ± 0%   +3.42%  (p=0.016 n=5+4)
_Mod/small/uint256-6     14.1ns ± 0%  13.9ns ± 0%   -1.42%  (p=0.008 n=5+5)
_SDiv/large/big-6         404ns ± 0%   405ns ± 0%   +0.25%  (p=0.029 n=4+4)
_SDiv/large/uint256-6     191ns ± 0%   191ns ± 0%     ~     (all equal)
SetFromBig/1word-6       29.3ns ± 0%   3.4ns ± 1%  -88.37%  (p=0.008 n=5+5)
SetFromBig/2words-6      48.3ns ± 0%   3.7ns ± 0%  -92.35%  (p=0.000 n=5+4)
SetFromBig/3words-6      66.8ns ± 0%   4.0ns ± 0%  -94.04%  (p=0.008 n=5+5)
SetFromBig/4words-6      80.6ns ± 0%   4.2ns ± 0%  -94.73%  (p=0.000 n=5+4)
SetFromBig/overflow-6    96.5ns ± 0%   4.2ns ± 0%  -95.60%  (p=0.008 n=5+5)
_AddMod/large/big-6       212ns ± 0%   212ns ± 0%     ~     (p=0.556 n=4+5)
_AddMod/large/uint256-6  39.5ns ± 0%  39.4ns ± 0%     ~     (p=0.079 n=5+5)
_AddMod/small/big-6      64.9ns ± 1%  64.9ns ± 0%     ~     (p=0.651 n=5+5)
_AddMod/small/uint256-6  17.5ns ± 0%  17.4ns ± 0%   -0.57%  (p=0.000 n=5+4)
```