### PR TITLE
Reciprocal-based 2by1 division procedure

### DIFF
--- a/div.go
+++ b/div.go
@@ -1,0 +1,34 @@
+package uint256
+
+import "math/bits"
+
+// reciprocal2by1 computes <^d, ^0> / d.
+func reciprocal2by1(d uint64) uint64 {
+	reciprocal, _ := bits.Div64(^d, ^uint64(0), d)
+	return reciprocal
+}
+
+// udivrem2by1 divides <uh, ul> / d and produces both quotient and remainder.
+// It uses the provided d's reciprocal.
+// Implementation ported from https://github.com/chfast/intx and is based on
+// "Improved division by invariant integers", Algorithm 4.
+func udivrem2by1(uh, ul, d, reciprocal uint64) (quot, rem uint64) {
+	qh, ql := bits.Mul64(reciprocal, uh)
+	ql, carry := bits.Add64(ql, ul, 0)
+	qh, _ = bits.Add64(qh, uh, carry)
+	qh++
+
+	r := ul - qh*d
+
+	if r > ql {
+		qh--
+		r += d
+	}
+
+	if r >= d {
+		qh++
+		r -= d
+	}
+
+	return qh, r
+}

--- a/uint256.go
+++ b/uint256.go
@@ -398,9 +398,10 @@ func subMulTo(x, y []uint64, multiplier uint64) uint64 {
 // udivremBy1 divides u by single normalized word d and produces both quotient and remainder.
 // The quotient is stored in provided quot.
 func udivremBy1(quot, u []uint64, d uint64) (rem uint64) {
+	reciprocal := reciprocal2by1(d)
 	rem = u[len(u)-1] // Set the top word as remainder.
 	for j := len(u) - 2; j >= 0; j-- {
-		quot[j], rem = bits.Div64(rem, u[j], d)
+		quot[j], rem = udivrem2by1(rem, u[j], d, reciprocal)
 	}
 	return rem
 }
@@ -411,6 +412,7 @@ func udivremBy1(quot, u []uint64, d uint64) (rem uint64) {
 func udivremKnuth(quot, u, d []uint64) {
 	dh := d[len(d)-1]
 	dl := d[len(d)-2]
+	reciprocal := reciprocal2by1(dh)
 
 	for j := len(u) - len(d) - 1; j >= 0; j-- {
 		u2 := u[j+len(d)]
@@ -422,7 +424,7 @@ func udivremKnuth(quot, u, d []uint64) {
 			qhat = ^uint64(0)
 			// TODO: Add "qhat one to big" adjustment (not needed for correctness, but helps avoiding "add back" case).
 		} else {
-			qhat, rhat = bits.Div64(u2, u1, dh)
+			qhat, rhat = udivrem2by1(u2, u1, dh, reciprocal)
 			ph, pl := bits.Mul64(qhat, dl)
 			if ph > rhat || (ph == rhat && pl > u0) {
 				qhat--


### PR DESCRIPTION
This is based on [Improved division by invariant integers](https://gmplib.org/~tege/division-paper.pdf) and ported from https://github.com/chfast/intx.

The computation of reciprocal is single `DIV` x86_64 instruction, but there exist faster implementation (sneak peek in #39) but I left it for other time.

```
name                     old time/op  new time/op  delta
_Div/large/big-6          246ns ± 0%   245ns ± 0%   -0.49%  (p=0.016 n=4+5)
_Div/large/uint256-6     99.2ns ± 0%  83.3ns ± 0%  -16.07%  (p=0.008 n=5+5)
_Div/small/big-6         68.8ns ± 0%  68.8ns ± 0%     ~     (p=0.500 n=5+5)
_Div/small/uint256-6     13.1ns ± 0%  13.0ns ± 0%   -0.76%  (p=0.008 n=5+5)
_MulMod/large/big-6       388ns ± 0%   388ns ± 0%     ~     (p=0.167 n=5+5)
_MulMod/large/uint256-6   204ns ± 0%   153ns ± 0%  -25.00%  (p=0.008 n=5+5)
_MulMod/small/big-6      94.1ns ± 1%  93.9ns ± 0%     ~     (p=0.397 n=5+5)
_MulMod/small/uint256-6  40.0ns ± 0%  40.0ns ± 0%     ~     (p=0.444 n=5+5)
MulMod/mod64-6            186ns ± 0%   101ns ± 0%  -45.70%  (p=0.008 n=5+5)
MulMod/mod128-6           266ns ± 0%   176ns ± 0%  -33.68%  (p=0.000 n=4+5)
MulMod/mod192-6           245ns ± 0%   173ns ± 0%     ~     (p=0.079 n=4+5)
MulMod/mod256-6           223ns ± 0%   169ns ± 0%  -24.22%  (p=0.000 n=5+4)
_Mod/large/big-6          137ns ± 0%   137ns ± 0%     ~     (all equal)
_Mod/large/uint256-6     50.2ns ± 0%  68.2ns ± 0%  +35.94%  (p=0.016 n=4+5)
_Mod/small/big-6         40.8ns ± 0%  40.9ns ± 0%     ~     (p=0.325 n=5+5)
_Mod/small/uint256-6     14.0ns ± 0%  14.0ns ± 0%     ~     (all equal)
_SDiv/large/big-6         402ns ± 0%   401ns ± 0%   -0.25%  (p=0.016 n=4+5)
_SDiv/large/uint256-6     105ns ± 0%    89ns ± 0%  -14.95%  (p=0.000 n=5+4)
_AddMod/large/big-6       212ns ± 0%   212ns ± 0%     ~     (all equal)
_AddMod/large/uint256-6  39.5ns ± 0%  39.9ns ± 1%   +0.96%  (p=0.024 n=5+5)
_AddMod/small/big-6      65.4ns ± 0%  65.3ns ± 1%     ~     (p=0.238 n=5+5)
_AddMod/small/uint256-6  17.2ns ± 0%  17.4ns ± 0%   +1.16%  (p=0.008 n=5+5)
```