### PR TITLE
Cleanups and optimization of ToBig()

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -16,8 +16,9 @@ const (
 	maxWords = 256 / bits.UintSize // number of big.Words in 256-bit
 )
 
-// NewFromBig creates new Int from big.Int.
-func NewFromBig(b *big.Int) (*Int, bool) {
+// FromBig is a convenience-constructor from big.Int.
+// Returns a new Int and whether overflow occurred.
+func FromBig(b *big.Int) (*Int, bool) {
 	z := &Int{}
 	overflow := z.SetFromBig(b)
 	return z, overflow

--- a/conversion.go
+++ b/conversion.go
@@ -16,11 +16,25 @@ const (
 	maxWords = 256 / bits.UintSize // number of big.Words in 256-bit
 )
 
+// ToBig returns a big.Int version of z.
 func (z *Int) ToBig() *big.Int {
-	x := new(big.Int)
-	b := z.Bytes()
-	x.SetBytes(b[:])
-	return x
+	b := new(big.Int)
+	switch maxWords { // Compile-time check.
+	case 4: // 64-bit architectures.
+		words := [4]big.Word{big.Word(z[0]), big.Word(z[1]), big.Word(z[2]), big.Word(z[3])}
+		b.SetBits(words[:])
+	case 8: // 32-bit architectures.
+		words := [8]big.Word{
+			big.Word(z[0]), big.Word(z[0] >> 32),
+			big.Word(z[1]), big.Word(z[1] >> 32),
+			big.Word(z[2]), big.Word(z[2] >> 32),
+			big.Word(z[3]), big.Word(z[3] >> 32),
+		}
+		return new(big.Int).SetBits(words[:])
+	default:
+		panic("unsupported architecture")
+	}
+	return b
 }
 
 // FromBig is a convenience-constructor from big.Int.

--- a/conversion.go
+++ b/conversion.go
@@ -16,6 +16,13 @@ const (
 	maxWords = 256 / bits.UintSize // number of big.Words in 256-bit
 )
 
+func (z *Int) ToBig() *big.Int {
+	x := new(big.Int)
+	b := z.Bytes()
+	x.SetBytes(b[:])
+	return x
+}
+
 // FromBig is a convenience-constructor from big.Int.
 // Returns a new Int and whether overflow occurred.
 func FromBig(b *big.Int) (*Int, bool) {

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -109,3 +109,25 @@ func BenchmarkSetFromBig(bench *testing.B) {
 	param5 := new(big.Int).Lsh(param4, 64)
 	bench.Run("overflow", func(bench *testing.B) { benchmarkSetFromBig(bench, param5) })
 }
+
+func benchmarkToBig(bench *testing.B, f *Int) *big.Int {
+	var b *big.Int
+	for i := 0; i < bench.N; i++ {
+		b = f.ToBig()
+	}
+	return b
+}
+
+func BenchmarkToBig(bench *testing.B) {
+	param1 := new(Int).SetUint64(0xff)
+	bench.Run("1word", func(bench *testing.B) { benchmarkToBig(bench, param1) })
+
+	param2 := new(Int).Lsh(param1, 64)
+	bench.Run("2words", func(bench *testing.B) { benchmarkToBig(bench, param2) })
+
+	param3 := new(Int).Lsh(param2, 64)
+	bench.Run("3words", func(bench *testing.B) { benchmarkToBig(bench, param3) })
+
+	param4 := new(Int).Lsh(param3, 64)
+	bench.Run("4words", func(bench *testing.B) { benchmarkToBig(bench, param4) })
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1,0 +1,127 @@
+// Copyright 2020 Martin Holst Swende. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the COPYING file.
+//
+
+package uint256
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+)
+
+func TestNewFromBig(t *testing.T) {
+	a := new(big.Int)
+	b, o := NewFromBig(a)
+	if o {
+		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
+	}
+	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
+		t.Fatalf("got %x exp %x", got, exp)
+	}
+
+	a = big.NewInt(1)
+	b, o = NewFromBig(a)
+	if o {
+		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
+	}
+	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
+		t.Fatalf("got %x exp %x", got, exp)
+	}
+
+	a = big.NewInt(0x1000000000000000)
+	b, o = NewFromBig(a)
+	if o {
+		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
+	}
+	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
+		t.Fatalf("got %x exp %x", got, exp)
+	}
+
+	a = big.NewInt(0x1234)
+	b, o = NewFromBig(a)
+	if o {
+		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
+	}
+	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
+		t.Fatalf("got %x exp %x", got, exp)
+	}
+
+	a = big.NewInt(1)
+	a.Lsh(a, 256)
+
+	b, o = NewFromBig(a)
+	if !o {
+		t.Fatalf("expected overflow")
+	}
+	if !b.Eq(new(Int)) {
+		t.Fatalf("got %x exp 0", b.Bytes())
+	}
+
+	a.Sub(a, big.NewInt(1))
+	b, o = NewFromBig(a)
+	if o {
+		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
+	}
+	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
+		t.Fatalf("got %x exp %x", got, exp)
+	}
+}
+
+func TestNewFromBigOverflow(t *testing.T) {
+	_, o := NewFromBig(new(big.Int).SetBytes(hex2Bytes("ababee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
+	if !o {
+		t.Errorf("expected overflow, got %v", o)
+	}
+	_, o = NewFromBig(new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
+	if o {
+		t.Errorf("expected no overflow, got %v", o)
+	}
+	b := new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199"))
+	_, o = NewFromBig(b.Neg(b))
+	if o {
+		t.Errorf("expected no overflow, got %v", o)
+	}
+}
+
+func TestFromBigOverflow(t *testing.T) {
+	_, o := FromBig(new(big.Int).SetBytes(hex2Bytes("ababee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
+	if !o {
+		t.Errorf("expected overflow, got %v", o)
+	}
+	_, o = FromBig(new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
+	if o {
+		t.Errorf("expected no overflow, got %v", o)
+	}
+	b := new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199"))
+	_, o = FromBig(b.Neg(b))
+	if o {
+		t.Errorf("expected no overflow, got %v", o)
+	}
+}
+
+func benchmarkSetFromBig(bench *testing.B, b *big.Int) Int {
+	var f Int
+	for i := 0; i < bench.N; i++ {
+		f.SetFromBig(b)
+	}
+	return f
+}
+
+func BenchmarkSetFromBig(bench *testing.B) {
+	param1 := big.NewInt(0xff)
+	bench.Run("1word", func(bench *testing.B) { benchmarkSetFromBig(bench, param1) })
+
+	param2 := new(big.Int).Lsh(param1, 64)
+	bench.Run("2words", func(bench *testing.B) { benchmarkSetFromBig(bench, param2) })
+
+	param3 := new(big.Int).Lsh(param2, 64)
+	bench.Run("3words", func(bench *testing.B) { benchmarkSetFromBig(bench, param3) })
+
+	param4 := new(big.Int).Lsh(param3, 64)
+	bench.Run("4words", func(bench *testing.B) { benchmarkSetFromBig(bench, param4) })
+
+	param5 := new(big.Int).Lsh(param4, 64)
+	bench.Run("overflow", func(bench *testing.B) { benchmarkSetFromBig(bench, param5) })
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -85,6 +85,24 @@ func TestFromBigOverflow(t *testing.T) {
 	}
 }
 
+func TestToBig(t *testing.T) {
+
+	if bigZero := new(Int).ToBig(); bigZero.Cmp(new(big.Int)) != 0 {
+		t.Errorf("expected big.Int 0, got %x", bigZero)
+	}
+
+	for i := uint(0); i < 256; i++ {
+		f := new(Int).SetUint64(1)
+		f.Lsh(f, i)
+		b := f.ToBig()
+		expected := big.NewInt(1)
+		expected.Lsh(expected, i)
+		if b.Cmp(expected) != 0 {
+			t.Fatalf("expected %x, got %x", expected, b)
+		}
+	}
+}
+
 func benchmarkSetFromBig(bench *testing.B, b *big.Int) Int {
 	var f Int
 	for i := 0; i < bench.N; i++ {

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 )
 
-func TestNewFromBig(t *testing.T) {
+func TestFromBig(t *testing.T) {
 	a := new(big.Int)
-	b, o := NewFromBig(a)
+	b, o := FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
@@ -22,7 +22,7 @@ func TestNewFromBig(t *testing.T) {
 	}
 
 	a = big.NewInt(1)
-	b, o = NewFromBig(a)
+	b, o = FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
@@ -31,7 +31,7 @@ func TestNewFromBig(t *testing.T) {
 	}
 
 	a = big.NewInt(0x1000000000000000)
-	b, o = NewFromBig(a)
+	b, o = FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
@@ -40,7 +40,7 @@ func TestNewFromBig(t *testing.T) {
 	}
 
 	a = big.NewInt(0x1234)
-	b, o = NewFromBig(a)
+	b, o = FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
@@ -51,7 +51,7 @@ func TestNewFromBig(t *testing.T) {
 	a = big.NewInt(1)
 	a.Lsh(a, 256)
 
-	b, o = NewFromBig(a)
+	b, o = FromBig(a)
 	if !o {
 		t.Fatalf("expected overflow")
 	}
@@ -60,28 +60,12 @@ func TestNewFromBig(t *testing.T) {
 	}
 
 	a.Sub(a, big.NewInt(1))
-	b, o = NewFromBig(a)
+	b, o = FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
 	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
 		t.Fatalf("got %x exp %x", got, exp)
-	}
-}
-
-func TestNewFromBigOverflow(t *testing.T) {
-	_, o := NewFromBig(new(big.Int).SetBytes(hex2Bytes("ababee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	if !o {
-		t.Errorf("expected overflow, got %v", o)
-	}
-	_, o = NewFromBig(new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
-	}
-	b := new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199"))
-	_, o = NewFromBig(b.Neg(b))
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
 	}
 }
 

--- a/uint256.go
+++ b/uint256.go
@@ -45,15 +45,6 @@ func NewInt() *Int {
 	return &Int{}
 }
 
-// FromBig is a convenience-constructor from big.Int.
-// returns a new Int and whether overflow occurred
-func FromBig(int *big.Int) (*Int, bool) {
-	// Let's not ruin the argument
-	z := &Int{}
-	overflow := z.SetFromBig(int)
-	return z, overflow
-}
-
 func (z *Int) ToBig() *big.Int {
 	x := new(big.Int)
 	b := z.Bytes()

--- a/uint256.go
+++ b/uint256.go
@@ -45,13 +45,6 @@ func NewInt() *Int {
 	return &Int{}
 }
 
-func (z *Int) ToBig() *big.Int {
-	x := new(big.Int)
-	b := z.Bytes()
-	x.SetBytes(b[:])
-	return x
-}
-
 // SetBytes interprets buf as the bytes of a big-endian unsigned
 // integer, sets z to that value, and returns z.
 func (z *Int) SetBytes(buf []byte) *Int {

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -1320,31 +1320,6 @@ func Benchmark_SDiv(bench *testing.B) {
 	bench.Run("large/uint256", benchmark_SdivLarge_Bit)
 }
 
-func benchmarkSetFromBig(bench *testing.B, b *big.Int) Int {
-	var f Int
-	for i := 0; i < bench.N; i++ {
-		f.SetFromBig(b)
-	}
-	return f
-}
-
-func BenchmarkSetFromBig(bench *testing.B) {
-	param1 := big.NewInt(0xff)
-	bench.Run("1word", func(bench *testing.B) { benchmarkSetFromBig(bench, param1) })
-
-	param2 := new(big.Int).Lsh(param1, 64)
-	bench.Run("2words", func(bench *testing.B) { benchmarkSetFromBig(bench, param2) })
-
-	param3 := new(big.Int).Lsh(param2, 64)
-	bench.Run("3words", func(bench *testing.B) { benchmarkSetFromBig(bench, param3) })
-
-	param4 := new(big.Int).Lsh(param3, 64)
-	bench.Run("4words", func(bench *testing.B) { benchmarkSetFromBig(bench, param4) })
-
-	param5 := new(big.Int).Lsh(param4, 64)
-	bench.Run("overflow", func(bench *testing.B) { benchmarkSetFromBig(bench, param5) })
-}
-
 func TestByteRepresentation(t *testing.T) {
 
 	//0e320219838e859b2f9f18b72e3d4073ca50b37d
@@ -1490,43 +1465,6 @@ func TestInt_WriteToArray(t *testing.T) {
 	}
 }
 
-func TestFromBFromBigigOld(t *testing.T) {
-	z, o := FromBig(new(big.Int).SetBytes(hex2Bytes("ababee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	fmt.Printf("z %x\n", z)
-	if !o {
-		t.Errorf("expected overflow, got %v", o)
-	}
-	_, o = FromBig(new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
-	}
-	b := new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199"))
-	z, o = FromBig(b.Neg(b))
-	fmt.Printf("z %x\n", z)
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
-	}
-
-}
-
-func TestFromBig(t *testing.T) {
-	z, o := NewFromBig(new(big.Int).SetBytes(hex2Bytes("ababee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	fmt.Printf("z %x\n", z)
-	if !o {
-		t.Errorf("expected overflow, got %v", o)
-	}
-	_, o = NewFromBig(new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199")))
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
-	}
-	b := new(big.Int).SetBytes(hex2Bytes("ee444444444444ffcc333333333333ddaa222222222222bb8811111111111199"))
-	z, o = NewFromBig(b.Neg(b))
-	fmt.Printf("z %x\n", z)
-	if o {
-		t.Errorf("expected no overflow, got %v", o)
-	}
-}
-
 type gethAddress [20]byte
 
 // SetBytes sets the address to the value of b.
@@ -1625,28 +1563,3 @@ func TestByte32Representation(t *testing.T) {
 	}
 }
 
-func TestConversion(t *testing.T) {
-	a := big.NewInt(1)
-	b, _ := NewFromBig(a)
-	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
-		t.Fatalf("got %x exp %x", got, exp)
-	}
-	fmt.Printf("big.Int:     %x\n", a.Bytes())
-	fmt.Printf("uint256.Int: %x\n", b.Bytes())
-	a = big.NewInt(0x1000000000000000)
-	b, _ = NewFromBig(a)
-	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
-		t.Fatalf("got %x exp %x", got, exp)
-	}
-	fmt.Printf("big.Int:     %x\n", a.Bytes())
-	fmt.Printf("uint256.Int: %x\n", b.Bytes())
-
-	a = big.NewInt(0x1234)
-	b, _ = NewFromBig(a)
-	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
-		t.Fatalf("got %x exp %x", got, exp)
-	}
-	fmt.Printf("big.Int:     %x\n", a.Bytes())
-	fmt.Printf("uint256.Int: %x\n", b.Bytes())
-
-}


### PR DESCRIPTION
```
name                     old time/op  new time/op  delta
ToBig/1word-6            64.9ns ± 0%  50.0ns ± 1%  -22.90%  (p=0.008 n=5+5)
ToBig/2words-6           90.6ns ± 0%  50.0ns ± 0%  -44.86%  (p=0.008 n=5+5)
ToBig/3words-6            111ns ± 0%    50ns ± 2%  -55.14%  (p=0.008 n=5+5)
ToBig/4words-6            126ns ± 0%    50ns ± 1%  -60.59%  (p=0.008 n=5+5)
_MulMod/large/uint256-6   628ns ± 0%   531ns ± 0%  -15.45%  (p=0.016 n=5+4)
```

1. Merge FromBig() and NewFromBig(). They were identical.
2. Adds more unit tests. Moves conversion tests to `conversion_test.go`.
3. Adds a benchmark for `ToBig()`.
4. Optimizes `ToBig()` in a similar way as `FromBig()` although in this case implementation is much simpler.

Probably the best to review commit by commit.