### PR TITLE
Eliminate allocations in division

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -444,7 +444,7 @@ func udivremKnuth(quot, u, d []uint64) {
 // The quotient is stored in provided quot - len(u)-len(d)+1 words.
 // It loosely follows the Knuth's division algorithm (sometimes referenced as "schoolbook" division) using 64-bit words.
 // See Knuth, Volume 2, section 4.3.1, Algorithm D.
-func udivrem(quot, u []uint64, d *Int) (rem *Int) {
+func udivrem(quot, u []uint64, d *Int) (rem Int) {
 	var dLen int
 	for i := len(d) - 1; i >= 0; i-- {
 		if d[i] != 0 {
@@ -482,12 +482,12 @@ func udivrem(quot, u []uint64, d *Int) (rem *Int) {
 
 	if dLen == 1 {
 		r := udivremBy1(quot, un, dn[0])
-		return new(Int).SetUint64(r >> shift)
+		rem.SetUint64(r >> shift)
+		return rem
 	}
 
 	udivremKnuth(quot, un, dn)
 
-	rem = new(Int)
 	for i := 0; i < dLen-1; i++ {
 		rem[i] = (un[i] >> shift) | (un[i+1] << (64 - shift))
 	}
@@ -546,7 +546,7 @@ func (z *Int) Mod(x, y *Int) *Int {
 
 	var quot Int
 	rem := udivrem(quot[:], x[:], y)
-	return z.Copy(rem)
+	return z.Copy(&rem)
 }
 
 // Smod interprets x and y as signed integers sets z to
@@ -594,7 +594,7 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 
 	var quot [8]uint64
 	rem := udivrem(quot[:], p[:], m)
-	return z.Copy(rem)
+	return z.Copy(&rem)
 }
 
 // Abs interprets x as a a signed number, and sets z to the Abs value

--- a/uint256.go
+++ b/uint256.go
@@ -394,21 +394,19 @@ func subMulTo(x, y []uint64, multiplier uint64) uint64 {
 }
 
 // udivremBy1 divides u by single normalized word d and produces both quotient and remainder.
-func udivremBy1(u []uint64, d uint64) (quot []uint64, rem uint64) {
-	quot = make([]uint64, len(u)-1)
+// The quotient is stored in provided quot.
+func udivremBy1(quot, u []uint64, d uint64) (rem uint64) {
 	rem = u[len(u)-1] // Set the top word as remainder.
-
 	for j := len(u) - 2; j >= 0; j-- {
 		quot[j], rem = bits.Div64(rem, u[j], d)
 	}
-
-	return quot, rem
+	return rem
 }
 
 // udivremKnuth implements the division of u by normalized multiple word d from the Knuth's division algorithm.
-// Returns quotient and updates u to contain the remainder.
-func udivremKnuth(u, d []uint64) (quot []uint64) {
-	quot = make([]uint64, len(u)-len(d))
+// The quotient is stored in provided quot - len(u)-len(d) words.
+// Updates u to contain the remainder - len(d) words.
+func udivremKnuth(quot, u, d []uint64) {
 	dh := d[len(d)-1]
 	dl := d[len(d)-2]
 
@@ -440,13 +438,13 @@ func udivremKnuth(u, d []uint64) (quot []uint64) {
 
 		quot[j] = qhat // Store quotient digit.
 	}
-	return quot
 }
 
 // udivrem divides u by d and produces both quotient and remainder.
+// The quotient is stored in provided quot - len(u)-len(d)+1 words.
 // It loosely follows the Knuth's division algorithm (sometimes referenced as "schoolbook" division) using 64-bit words.
 // See Knuth, Volume 2, section 4.3.1, Algorithm D.
-func udivrem(u []uint64, d *Int) (quot []uint64, rem *Int) {
+func udivrem(quot, u []uint64, d *Int) (rem *Int) {
 	var dLen int
 	for i := len(d) - 1; i >= 0; i-- {
 		if d[i] != 0 {
@@ -483,11 +481,11 @@ func udivrem(u []uint64, d *Int) (quot []uint64, rem *Int) {
 	// TODO: Skip the highest word of numerator if not significant.
 
 	if dLen == 1 {
-		quot, r := udivremBy1(un, dn[0])
-		return quot, new(Int).SetUint64(r >> shift)
+		r := udivremBy1(quot, un, dn[0])
+		return new(Int).SetUint64(r >> shift)
 	}
 
-	quot = udivremKnuth(un, dn)
+	udivremKnuth(quot, un, dn)
 
 	rem = new(Int)
 	for i := 0; i < dLen-1; i++ {
@@ -495,7 +493,7 @@ func udivrem(u []uint64, d *Int) (quot []uint64, rem *Int) {
 	}
 	rem[dLen-1] = un[dLen-1] >> shift
 
-	return quot, rem
+	return rem
 }
 
 // Div sets z to the quotient x/y for returns z.
@@ -515,10 +513,9 @@ func (z *Int) Div(x, y *Int) *Int {
 	// At this point, we know
 	// x/y ; x > y > 0
 
-	quot, _ := udivrem(x[:], y)
-	z.Clear()
-	copy(z[:len(quot)], quot)
-	return z
+	var quot Int
+	udivrem(quot[:], x[:], y)
+	return z.Copy(&quot)
 }
 
 // Mod sets z to the modulus x%y for y != 0 and returns z.
@@ -547,7 +544,8 @@ func (z *Int) Mod(x, y *Int) *Int {
 		return z.SetUint64(x.Uint64() % y.Uint64())
 	}
 
-	_, rem := udivrem(x[:], y)
+	var quot Int
+	rem := udivrem(quot[:], x[:], y)
 	return z.Copy(rem)
 }
 
@@ -594,7 +592,8 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 		return z
 	}
 
-	_, rem := udivrem(p[:], m)
+	var quot [8]uint64
+	rem := udivrem(quot[:], p[:], m)
 	return z.Copy(rem)
 }
 


### PR DESCRIPTION
The `uint256` is now allocation free!

```
name                     old time/op    new time/op    delta
_Div/large/big-6            245ns ± 0%     245ns ± 0%      ~     (p=0.333 n=4+5)
_Div/large/uint256-6        139ns ± 0%      99ns ± 0%   -28.72%  (p=0.008 n=5+5)
_Div/small/big-6           69.0ns ± 1%    68.8ns ± 0%      ~     (p=0.159 n=5+5)
_Div/small/uint256-6       13.0ns ± 0%    13.1ns ± 0%      ~     (p=0.167 n=5+5)
_MulMod/large/big-6         388ns ± 0%     388ns ± 0%      ~     (p=1.000 n=5+5)
_MulMod/large/uint256-6     243ns ± 0%     204ns ± 0%   -16.05%  (p=0.008 n=5+5)
_MulMod/small/big-6        94.1ns ± 0%    93.9ns ± 0%      ~     (p=0.222 n=5+5)
_MulMod/small/uint256-6    40.4ns ± 0%    39.9ns ± 0%    -1.24%  (p=0.000 n=5+4)
MulMod/mod64-6              230ns ± 0%     186ns ± 0%   -19.13%  (p=0.008 n=5+5)
MulMod/mod128-6             302ns ± 0%     266ns ± 0%   -11.80%  (p=0.008 n=5+5)
MulMod/mod192-6             281ns ± 0%     246ns ± 0%   -12.47%  (p=0.008 n=5+5)
MulMod/mod256-6             259ns ± 1%     223ns ± 0%   -13.77%  (p=0.000 n=5+4)
_Mod/large/big-6            137ns ± 0%     136ns ± 0%      ~     (p=0.079 n=4+5)
_Mod/large/uint256-6       79.4ns ± 0%    50.2ns ± 0%   -36.74%  (p=0.016 n=5+4)
_Mod/small/big-6           40.9ns ± 0%    40.7ns ± 0%    -0.49%  (p=0.029 n=4+4)
_Mod/small/uint256-6       15.4ns ± 4%    14.0ns ± 0%    -8.97%  (p=0.008 n=5+5)
_SDiv/large/big-6           404ns ± 0%     401ns ± 0%    -0.64%  (p=0.008 n=5+5)
_SDiv/large/uint256-6       146ns ± 0%     105ns ± 0%   -28.08%  (p=0.008 n=5+5)
_AddMod/large/big-6         212ns ± 0%     212ns ± 0%      ~     (p=0.444 n=5+5)
_AddMod/large/uint256-6    39.5ns ± 0%    39.6ns ± 0%      ~     (p=0.444 n=5+5)
_AddMod/small/big-6        65.3ns ± 0%    65.5ns ± 0%      ~     (p=0.079 n=4+5)
_AddMod/small/uint256-6    17.4ns ± 0%    17.2ns ± 0%    -1.15%  (p=0.008 n=5+5)

name                     old alloc/op   new alloc/op   delta
_Div/large/big-6             144B ± 0%      144B ± 0%      ~     (all equal)
_Div/large/uint256-6        64.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
_Div/small/big-6            16.0B ± 0%     16.0B ± 0%      ~     (all equal)
_Div/small/uint256-6        0.00B          0.00B           ~     (all equal)
_MulMod/large/big-6          176B ± 0%      176B ± 0%      ~     (all equal)
_MulMod/large/uint256-6     80.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
_MulMod/small/big-6         56.0B ± 0%     56.0B ± 0%      ~     (all equal)
_MulMod/small/uint256-6     0.00B          0.00B           ~     (all equal)
MulMod/mod64-6              96.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
MulMod/mod128-6             96.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
MulMod/mod192-6             80.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
MulMod/mod256-6             80.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
_Mod/large/big-6            8.00B ± 0%     8.00B ± 0%      ~     (all equal)
_Mod/large/uint256-6        40.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
_Mod/small/big-6            8.00B ± 0%     8.00B ± 0%      ~     (all equal)
_Mod/small/uint256-6        0.00B          0.00B           ~     (all equal)
_SDiv/large/big-6            248B ± 0%      248B ± 0%      ~     (all equal)
_SDiv/large/uint256-6       64.0B ± 0%      0.0B       -100.00%  (p=0.008 n=5+5)
_AddMod/large/big-6         48.0B ± 0%     48.0B ± 0%      ~     (all equal)
_AddMod/large/uint256-6     0.00B          0.00B           ~     (all equal)
_AddMod/small/big-6         8.00B ± 0%     8.00B ± 0%      ~     (all equal)
_AddMod/small/uint256-6     0.00B          0.00B           ~     (all equal)

name                     old allocs/op  new allocs/op  delta
_Div/large/big-6             2.00 ± 0%      2.00 ± 0%      ~     (all equal)
_Div/large/uint256-6         2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
_Div/small/big-6             2.00 ± 0%      2.00 ± 0%      ~     (all equal)
_Div/small/uint256-6         0.00           0.00           ~     (all equal)
_MulMod/large/big-6          2.00 ± 0%      2.00 ± 0%      ~     (all equal)
_MulMod/large/uint256-6      2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
_MulMod/small/big-6          2.00 ± 0%      2.00 ± 0%      ~     (all equal)
_MulMod/small/uint256-6      0.00           0.00           ~     (all equal)
MulMod/mod64-6               2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
MulMod/mod128-6              2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
MulMod/mod192-6              2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
MulMod/mod256-6              2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
_Mod/large/big-6             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
_Mod/large/uint256-6         2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
_Mod/small/big-6             1.00 ± 0%      1.00 ± 0%      ~     (all equal)
_Mod/small/uint256-6         0.00           0.00           ~     (all equal)
_SDiv/large/big-6            5.00 ± 0%      5.00 ± 0%      ~     (all equal)
_SDiv/large/uint256-6        2.00 ± 0%      0.00       -100.00%  (p=0.008 n=5+5)
_AddMod/large/big-6          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
_AddMod/large/uint256-6      0.00           0.00           ~     (all equal)
_AddMod/small/big-6          1.00 ± 0%      1.00 ± 0%      ~     (all equal)
_AddMod/small/uint256-6      0.00           0.00           ~     (all equal)
```