### PR TITLE
test: Fuzz with go-fuzz

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -15,7 +15,7 @@ commands:
             export GOARCH=<<parameters.arch>>
             go version
             go env
-            go test -v
+            go test -v -coverprofile=coverage-<<parameters.arch>>.txt -covermode=count
 
 jobs:
 
@@ -35,6 +35,9 @@ jobs:
           arch: "amd64"
       - test:
           arch: "386"
+      - run:
+          name: "Codecov upload"
+          command: bash <(curl -s https://codecov.io/bash)
       - run:
           name: "Benchmark"
           command: go test -run=- -bench=. -benchmem

--- a/circle.yml
+++ b/circle.yml
@@ -38,6 +38,20 @@ jobs:
       - run:
           name: "Codecov upload"
           command: bash <(curl -s https://codecov.io/bash)
+      - restore_cache:
+          keys:
+            - corpus
+      - run:
+          name: "Fuzzing"
+          command: |
+            go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+            go-fuzz-build
+            timeout --preserve-status --signal INT 1m go-fuzz -procs=2
+            test ! "$(ls crashers)"
+      - save_cache:
+          key: corpus-{{ epoch }}
+          paths:
+            - corpus
       - run:
           name: "Benchmark"
           command: go test -run=- -bench=. -benchmem

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  require_ci_to_pass: no
+
+coverage:
+  status:
+    project: no
+    patch: no
+
+comment:
+  layout: "diff"

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,58 @@
+// +build gofuzz
+
+package uint256
+
+const (
+	opUdivrem = 0
+	opMul     = 1
+)
+
+func Fuzz(data []byte) int {
+	if len(data) != 65 {
+		return 0
+	}
+
+	op := data[0]
+
+	var x, y Int
+	x.SetBytes(data[1:33])
+	y.SetBytes(data[33:])
+
+	bx := x.ToBig()
+	by := y.ToBig()
+
+	switch op {
+	case opUdivrem:
+		if y.IsZero() {
+			return 0
+		}
+
+		var q, r Int
+		q.Div(&x, &y)
+		r.Mod(&x, &y)
+		bx.QuoRem(bx, by, by)
+		eq, _ := FromBig(bx)
+		er, _ := FromBig(by)
+
+		if !q.Eq(eq) {
+			panic("invalid quotient")
+		}
+
+		if !r.Eq(er) {
+			panic("invalid remainder")
+		}
+
+	case opMul:
+		var p Int
+		p.Mul(&x, &y)
+
+		bx.Mul(bx, by)
+		ep, _ := FromBig(bx)
+
+		if !p.Eq(ep) {
+			panic("invalid multiplication result")
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
1. Adds basic go-fuzz fuzzer - can be extended later.
2. Collects testing code coverage (both amd64 and 386) and uploads to codecov for visual report.
3. The fuzzer runs on CI for one minute. The corpus is preserved.