### PR TITLE
Optimizations

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -287,6 +287,36 @@ func Benchmark_Cmp(bench *testing.B) {
 	bench.Run("single/uint256", benchmark_Cmp_Bit)
 }
 
+func BenchmarkLt(b *testing.B) {
+	benchmarkUint256 := func(b *testing.B, samples *[numSamples]Int) (flag bool) {
+		var x Int
+		for j := 0; j < b.N; j += numSamples {
+			for i := 0; i < numSamples; i++ {
+				y := samples[i]
+				flag = x.Lt(&y)
+				x = y
+			}
+		}
+		return
+	}
+	benchmarkBig := func(b *testing.B, samples *[numSamples]big.Int) (flag bool) {
+		var x big.Int
+		for j := 0; j < b.N; j += numSamples {
+			for i := 0; i < numSamples; i++ {
+				y := samples[i]
+				flag = x.Cmp(&y) < 0
+				x = y
+			}
+		}
+		return
+	}
+
+	b.Run("large/uint256", func(b *testing.B) { benchmarkUint256(b, &int256Samples) })
+	b.Run("large/big", func(b *testing.B) { benchmarkBig(b, &big256Samples) })
+	b.Run("small/uint256", func(b *testing.B) { benchmarkUint256(b, &int64Samples) })
+	b.Run("small/big", func(b *testing.B) { benchmarkBig(b, &big64Samples) })
+}
+
 func benchmark_Lsh_Big(n uint, bench *testing.B) {
 	original := big.NewInt(0).SetBytes(hex2Bytes("FBCDEF090807060504030201ffffffffFBCDEF090807060504030201ffffffff"))
 	bench.ResetTimer()

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -96,8 +96,8 @@ func benchmark_Add_Big(bench *testing.B) {
 	}
 }
 func Benchmark_Add(bench *testing.B) {
-	bench.Run("big", benchmark_Add_Big)
-	bench.Run("uint256", benchmark_Add_Bit)
+	bench.Run("single/big", benchmark_Add_Big)
+	bench.Run("single/uint256", benchmark_Add_Bit)
 }
 
 func benchmark_SubOverflow_Bit(bench *testing.B) {
@@ -133,9 +133,9 @@ func benchmark_Sub_Big(bench *testing.B) {
 	}
 }
 func Benchmark_Sub(bench *testing.B) {
-	bench.Run("big", benchmark_Sub_Big)
-	bench.Run("uint256", benchmark_Sub_Bit)
-	bench.Run("uint256_of", benchmark_SubOverflow_Bit)
+	bench.Run("single/big", benchmark_Sub_Big)
+	bench.Run("single/uint256", benchmark_Sub_Bit)
+	bench.Run("single/uint256_of", benchmark_SubOverflow_Bit)
 }
 
 func benchmark_Mul_Big(bench *testing.B) {
@@ -185,12 +185,12 @@ func benchmark_Squared_Big(bench *testing.B) {
 }
 
 func Benchmark_Mul(bench *testing.B) {
-	bench.Run("big", benchmark_Mul_Big)
-	bench.Run("uint256", benchmark_Mul_Bit)
+	bench.Run("single/big", benchmark_Mul_Big)
+	bench.Run("single/uint256", benchmark_Mul_Bit)
 }
 func Benchmark_Square(bench *testing.B) {
-	bench.Run("big", benchmark_Squared_Big)
-	bench.Run("uint256", benchmark_Squared_Bit)
+	bench.Run("single/big", benchmark_Squared_Big)
+	bench.Run("single/uint256", benchmark_Squared_Bit)
 }
 
 func benchmark_And_Big(bench *testing.B) {
@@ -212,8 +212,8 @@ func benchmark_And_Bit(bench *testing.B) {
 	}
 }
 func Benchmark_And(bench *testing.B) {
-	bench.Run("big", benchmark_And_Big)
-	bench.Run("uint256", benchmark_And_Bit)
+	bench.Run("single/big", benchmark_And_Big)
+	bench.Run("single/uint256", benchmark_And_Bit)
 }
 
 func benchmark_Or_Big(bench *testing.B) {
@@ -235,8 +235,8 @@ func benchmark_Or_Bit(bench *testing.B) {
 	}
 }
 func Benchmark_Or(bench *testing.B) {
-	bench.Run("big", benchmark_Or_Big)
-	bench.Run("uint256", benchmark_Or_Bit)
+	bench.Run("single/big", benchmark_Or_Big)
+	bench.Run("single/uint256", benchmark_Or_Bit)
 }
 
 func benchmark_Xor_Big(bench *testing.B) {
@@ -259,8 +259,8 @@ func benchmark_Xor_Bit(bench *testing.B) {
 }
 
 func Benchmark_Xor(bench *testing.B) {
-	bench.Run("big", benchmark_Xor_Big)
-	bench.Run("uint256", benchmark_Xor_Bit)
+	bench.Run("single/big", benchmark_Xor_Big)
+	bench.Run("single/uint256", benchmark_Xor_Bit)
 }
 
 func benchmark_Cmp_Big(bench *testing.B) {
@@ -283,8 +283,8 @@ func benchmark_Cmp_Bit(bench *testing.B) {
 	}
 }
 func Benchmark_Cmp(bench *testing.B) {
-	bench.Run("big", benchmark_Cmp_Big)
-	bench.Run("uint256", benchmark_Cmp_Bit)
+	bench.Run("single/big", benchmark_Cmp_Big)
+	bench.Run("single/uint256", benchmark_Cmp_Bit)
 }
 
 func benchmark_Lsh_Big(n uint, bench *testing.B) {
@@ -335,17 +335,17 @@ func benchmark_Lsh_Bit_N_GT_0(bench *testing.B) {
 	benchmark_Lsh_Bit(1, bench)
 }
 func Benchmark_Lsh(bench *testing.B) {
-	bench.Run("big/n_eq_0", benchmark_Lsh_Big_N_EQ_0)
-	bench.Run("big/n_gt_192", benchmark_Lsh_Big_N_GT_192)
-	bench.Run("big/n_gt_128", benchmark_Lsh_Big_N_GT_128)
-	bench.Run("big/n_gt_64", benchmark_Lsh_Big_N_GT_64)
-	bench.Run("big/n_gt_0", benchmark_Lsh_Big_N_GT_0)
+	bench.Run("n_eq_0/big", benchmark_Lsh_Big_N_EQ_0)
+	bench.Run("n_gt_192/big", benchmark_Lsh_Big_N_GT_192)
+	bench.Run("n_gt_128/big", benchmark_Lsh_Big_N_GT_128)
+	bench.Run("n_gt_64/big", benchmark_Lsh_Big_N_GT_64)
+	bench.Run("n_gt_0/big", benchmark_Lsh_Big_N_GT_0)
 
-	bench.Run("uint256/n_eq_0", benchmark_Lsh_Bit_N_EQ_0)
-	bench.Run("uint256/n_gt_192", benchmark_Lsh_Bit_N_GT_192)
-	bench.Run("uint256/n_gt_128", benchmark_Lsh_Bit_N_GT_128)
-	bench.Run("uint256/n_gt_64", benchmark_Lsh_Bit_N_GT_64)
-	bench.Run("uint256/n_gt_0", benchmark_Lsh_Bit_N_GT_0)
+	bench.Run("n_eq_0/uint256", benchmark_Lsh_Bit_N_EQ_0)
+	bench.Run("n_gt_192/uint256", benchmark_Lsh_Bit_N_GT_192)
+	bench.Run("n_gt_128/uint256", benchmark_Lsh_Bit_N_GT_128)
+	bench.Run("n_gt_64/uint256", benchmark_Lsh_Bit_N_GT_64)
+	bench.Run("n_gt_0/uint256", benchmark_Lsh_Bit_N_GT_0)
 }
 
 func benchmark_Rsh_Big(n uint, bench *testing.B) {
@@ -396,17 +396,17 @@ func benchmark_Rsh_Bit_N_GT_0(bench *testing.B) {
 	benchmark_Rsh_Bit(1, bench)
 }
 func Benchmark_Rsh(bench *testing.B) {
-	bench.Run("big/n_eq_0", benchmark_Rsh_Big_N_EQ_0)
-	bench.Run("big/n_gt_192", benchmark_Rsh_Big_N_GT_192)
-	bench.Run("big/n_gt_128", benchmark_Rsh_Big_N_GT_128)
-	bench.Run("big/n_gt_64", benchmark_Rsh_Big_N_GT_64)
-	bench.Run("big/n_gt_0", benchmark_Rsh_Big_N_GT_0)
+	bench.Run("n_eq_0/big", benchmark_Rsh_Big_N_EQ_0)
+	bench.Run("n_gt_192/big", benchmark_Rsh_Big_N_GT_192)
+	bench.Run("n_gt_128/big", benchmark_Rsh_Big_N_GT_128)
+	bench.Run("n_gt_64/big", benchmark_Rsh_Big_N_GT_64)
+	bench.Run("n_gt_0/big", benchmark_Rsh_Big_N_GT_0)
 
-	bench.Run("uint256/n_eq_0", benchmark_Rsh_Bit_N_EQ_0)
-	bench.Run("uint256/n_gt_192", benchmark_Rsh_Bit_N_GT_192)
-	bench.Run("uint256/n_gt_128", benchmark_Rsh_Bit_N_GT_128)
-	bench.Run("uint256/n_gt_64", benchmark_Rsh_Bit_N_GT_64)
-	bench.Run("uint256/n_gt_0", benchmark_Rsh_Bit_N_GT_0)
+	bench.Run("n_eq_0/uint256", benchmark_Rsh_Bit_N_EQ_0)
+	bench.Run("n_gt_192/uint256", benchmark_Rsh_Bit_N_GT_192)
+	bench.Run("n_gt_128/uint256", benchmark_Rsh_Bit_N_GT_128)
+	bench.Run("n_gt_64/uint256", benchmark_Rsh_Bit_N_GT_64)
+	bench.Run("n_gt_0/uint256", benchmark_Rsh_Bit_N_GT_0)
 }
 
 func benchmark_Exp_Big(bench *testing.B) {

--- a/conversion.go
+++ b/conversion.go
@@ -30,7 +30,7 @@ func (z *Int) ToBig() *big.Int {
 			big.Word(z[2]), big.Word(z[2] >> 32),
 			big.Word(z[3]), big.Word(z[3] >> 32),
 		}
-		return new(big.Int).SetBits(words[:])
+		b.SetBits(words[:])
 	default:
 		panic("unsupported architecture")
 	}

--- a/uint256.go
+++ b/uint256.go
@@ -148,7 +148,11 @@ func (z *Int) Clone() *Int {
 
 // Add sets z to the sum x+y
 func (z *Int) Add(x, y *Int) *Int {
-	z.AddOverflow(x, y) // Inlined.
+	var carry uint64
+	z[0], carry = bits.Add64(x[0], y[0], 0)
+	z[1], carry = bits.Add64(x[1], y[1], carry)
+	z[2], carry = bits.Add64(x[2], y[2], carry)
+	z[3], _ = bits.Add64(x[3], y[3], carry)
 	return z
 }
 
@@ -225,7 +229,7 @@ func (z *Int) Sub64(x *Int, y uint64) {
 // Sub sets z to the difference x-y and returns true if the operation underflowed
 func (z *Int) SubOverflow(x, y *Int) bool {
 	var carry uint64
-	z[0], carry = bits.Sub64(x[0], y[0], carry)
+	z[0], carry = bits.Sub64(x[0], y[0], 0)
 	z[1], carry = bits.Sub64(x[1], y[1], carry)
 	z[2], carry = bits.Sub64(x[2], y[2], carry)
 	z[3], carry = bits.Sub64(x[3], y[3], carry)
@@ -234,7 +238,11 @@ func (z *Int) SubOverflow(x, y *Int) bool {
 
 // Sub sets z to the difference x-y
 func (z *Int) Sub(x, y *Int) *Int {
-	z.SubOverflow(x, y) // Inlined.
+	var carry uint64
+	z[0], carry = bits.Sub64(x[0], y[0], 0)
+	z[1], carry = bits.Sub64(x[1], y[1], carry)
+	z[2], carry = bits.Sub64(x[2], y[2], carry)
+	z[3], _ = bits.Sub64(x[3], y[3], carry)
 	return z
 }
 

--- a/uint256.go
+++ b/uint256.go
@@ -1234,8 +1234,6 @@ func (z *Int) SignExtend(back, num *Int) {
 
 }
 
-var _ fmt.Formatter = zero
-
 func (z *Int) Format(s fmt.State, ch rune) {
 	z.ToBig().Format(s, ch)
 }

--- a/uint256.go
+++ b/uint256.go
@@ -26,7 +26,6 @@ var (
 		0x0000000000000000,
 		0x8000000000000000,
 	}
-	zero = &Int{}
 )
 
 // Int is represented as an array of 4 uint64, in little-endian order,

--- a/uint256.go
+++ b/uint256.go
@@ -183,7 +183,7 @@ func (z *Int) AddMod(x, y, m *Int) *Int {
 // addMiddle128 adds two uint64 integers to the upper part of z
 func addTo128(z []uint64, x0, x1 uint64) {
 	var carry uint64
-	z[0], carry = bits.Add64(z[0], x0, carry) // TODO: The order of adding x, y is confusing.
+	z[0], carry = bits.Add64(z[0], x0, carry)
 	z[1], _ = bits.Add64(z[1], x1, carry)
 }
 

--- a/uint256.go
+++ b/uint256.go
@@ -721,25 +721,7 @@ func (z *Int) Not() *Int {
 
 // Gt returns true if z > x
 func (z *Int) Gt(x *Int) bool {
-	if z[3] > x[3] {
-		return true
-	}
-	if z[3] < x[3] {
-		return false
-	}
-	if z[2] > x[2] {
-		return true
-	}
-	if z[2] < x[2] {
-		return false
-	}
-	if z[1] > x[1] {
-		return true
-	}
-	if z[1] < x[1] {
-		return false
-	}
-	return z[0] > x[0]
+	return x.Lt(z)
 }
 
 // Slt interprets z and x as signed integers, and returns
@@ -786,25 +768,12 @@ func (z *Int) SetIfGt(x *Int) {
 
 // Lt returns true if z < x
 func (z *Int) Lt(x *Int) bool {
-	if z[3] < x[3] {
-		return true
-	}
-	if z[3] > x[3] {
-		return false
-	}
-	if z[2] < x[2] {
-		return true
-	}
-	if z[2] > x[2] {
-		return false
-	}
-	if z[1] < x[1] {
-		return true
-	}
-	if z[1] > x[1] {
-		return false
-	}
-	return z[0] < x[0]
+	// z < x <=> z - x < 0 i.e. when subtraction overflows.
+	_, carry := bits.Sub64(z[0], x[0], 0)
+	_, carry = bits.Sub64(z[1], x[1], carry)
+	_, carry = bits.Sub64(z[2], x[2], carry)
+	_, carry = bits.Sub64(z[3], x[3], carry)
+	return carry != 0
 }
 
 // SetIfLt sets z to 1 if z < x
@@ -881,7 +850,7 @@ func (z *Int) IsZero() bool {
 
 // IsOne returns true if z == 1
 func (z *Int) IsOne() bool {
-	return (z[0] == 1) && (z[1] | z[2] | z[3]) == 0
+	return (z[0] == 1) && (z[1]|z[2]|z[3]) == 0
 }
 
 // Clear sets z to 0

--- a/uint256.go
+++ b/uint256.go
@@ -166,29 +166,18 @@ func (z *Int) AddOverflow(x, y *Int) bool {
 	return carry != 0
 }
 
-// Add sets z to the sum ( x+y ) mod m
-func (z *Int) AddMod(x, y, m *Int) {
-
-	if z == m { //z is an alias for m
+// AddMod sets z to the sum ( x+y ) mod m, and returns z
+func (z *Int) AddMod(x, y, m *Int) *Int {
+	if z == m { // z is an alias for m  // TODO: Understand why needed and add tests for all "division" methods.
 		m = m.Clone()
 	}
 	if overflow := z.AddOverflow(x, y); overflow {
-		// It overflowed. the actual value is
-		// 0x10 00..0 + 0x???..??
-		//
-		// We can split it into
-		// 0xffff...f + 0x1 + 0x???..??
-		// And mod each item individually
-		a := NewInt().SetAllOne()
-		a.Mod(a, m)
-		z.Mod(z, m)
-		z.Add(z, a)
-		// reuse a
-		a.SetOne()
-		z.Add(z, a)
-
+		sum := [5]uint64{z[0], z[1], z[2], z[3], 1}
+		var quot [5]uint64
+		rem := udivrem(quot[:], sum[:], m)
+		return z.Copy(&rem)
 	}
-	z.Mod(z, m)
+	return z.Mod(z, m)
 }
 
 // addMiddle128 adds two uint64 integers to the upper part of z

--- a/uint256.go
+++ b/uint256.go
@@ -608,11 +608,12 @@ func (z *Int) Abs() *Int {
 	if z.Lt(SignedMin) {
 		return z
 	}
-	z.Sub(zero, z)
+	z.Sub(&Int{}, z)
 	return z
 }
+
 func (z *Int) Neg() *Int {
-	z.Sub(zero, z)
+	z.Sub(&Int{}, z)
 	return z
 }
 

--- a/uint256.go
+++ b/uint256.go
@@ -876,12 +876,12 @@ func (z *Int) IsUint128() bool {
 
 // IsZero returns true if z == 0
 func (z *Int) IsZero() bool {
-	return (z[3] == 0) && (z[2] == 0) && (z[1] == 0) && (z[0] == 0)
+	return (z[0] | z[1] | z[2] | z[3]) == 0
 }
 
 // IsOne returns true if z == 1
 func (z *Int) IsOne() bool {
-	return (z[3] == 0) && (z[2] == 0) && (z[1] == 0) && (z[0] == 1)
+	return (z[0] == 1) && (z[1] | z[2] | z[3]) == 0
 }
 
 // Clear sets z to 0

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -915,7 +915,6 @@ func TestByte20Representation(t *testing.T) {
 		if got != exp {
 			t.Errorf("testcase %d: got %x exp %x", i, got, exp)
 		}
-		fmt.Printf("got %x \n", got)
 	}
 }
 
@@ -945,6 +944,5 @@ func TestByte32Representation(t *testing.T) {
 		if got != exp {
 			t.Errorf("testcase %d: got %x exp %x", i, got, exp)
 		}
-		fmt.Printf("got %x \n", got)
 	}
 }

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -17,6 +17,8 @@ import (
 var (
 	bigtt256 = new(big.Int).Lsh(big.NewInt(1), 256)
 	bigtt255 = new(big.Int).Lsh(big.NewInt(1), 255)
+
+	_ fmt.Formatter = &Int{} // Test if Int supports Formatter interface.
 )
 
 func hex2Bytes(str string) []byte {


### PR DESCRIPTION
```
name                      old time/op  new time/op  delta
_Add/single/uint256-6     3.08ns ± 0%  1.82ns ± 0%  -40.91%  (p=0.008 n=5+5)
_Sub/single/uint256-6     3.09ns ± 0%  1.82ns ± 0%  -41.10%  (p=0.008 n=5+5)
_Sub/single/uint256_of-6  1.82ns ± 0%  1.82ns ± 0%     ~     (all equal)
_Mul/single/uint256-6     15.9ns ± 0%  13.6ns ± 0%     ~     (p=0.079 n=4+5)
_Square/single/uint256-6  16.0ns ± 0%  14.6ns ± 0%   -8.27%  (p=0.008 n=5+5)
_And/single/uint256-6     1.67ns ± 5%  1.67ns ± 5%     ~     (p=1.000 n=5+5)
_Or/single/uint256-6      1.62ns ± 1%  1.61ns ± 1%     ~     (p=0.524 n=5+5)
_Xor/single/uint256-6     1.61ns ± 0%  1.66ns ± 5%     ~     (p=0.556 n=4+5)
_Cmp/single/uint256-6     2.96ns ± 0%  2.58ns ± 0%     ~     (p=0.079 n=4+5)
Lt/large/uint256-6        5.29ns ± 0%  2.53ns ± 0%  -52.21%  (p=0.008 n=5+5)
Lt/small/uint256-6        3.70ns ± 0%  2.53ns ± 0%  -31.48%  (p=0.008 n=5+5)
_Lsh/n_eq_0/uint256-6     4.09ns ± 0%  4.09ns ± 0%     ~     (all equal)
_Lsh/n_gt_192/uint256-6   4.32ns ± 0%  4.32ns ± 0%     ~     (all equal)
_Lsh/n_gt_128/uint256-6   5.50ns ± 0%  5.54ns ± 2%     ~     (p=0.079 n=4+5)
_Lsh/n_gt_64/uint256-6    7.30ns ± 0%  7.31ns ± 0%     ~     (p=0.722 n=5+5)
_Lsh/n_gt_0/uint256-6     8.19ns ± 0%  8.19ns ± 0%     ~     (all equal)
_Rsh/n_eq_0/uint256-6     4.09ns ± 0%  4.09ns ± 0%     ~     (all equal)
_Rsh/n_gt_192/uint256-6   4.32ns ± 0%  4.32ns ± 0%     ~     (all equal)
_Rsh/n_gt_128/uint256-6   5.56ns ± 0%  5.56ns ± 0%     ~     (p=0.333 n=4+5)
_Rsh/n_gt_64/uint256-6    7.23ns ± 0%  7.23ns ± 0%     ~     (all equal)
_Rsh/n_gt_0/uint256-6     8.19ns ± 0%  8.19ns ± 0%     ~     (all equal)
_Exp/large/uint256-6      6.89µs ± 0%  6.00µs ± 0%  -12.90%  (p=0.008 n=5+5)
_Exp/small/uint256-6       594ns ± 0%   516ns ± 0%  -13.13%  (p=0.008 n=5+5)
Div/small/uint256-6       13.0ns ± 0%  11.4ns ± 0%     ~     (p=0.079 n=4+5)
Div/mod64/uint256-6       57.4ns ± 0%  57.4ns ± 0%     ~     (p=0.444 n=5+5)
Div/mod128/uint256-6      89.3ns ± 0%  89.3ns ± 0%     ~     (p=0.397 n=5+5)
Div/mod192/uint256-6      80.1ns ± 0%  80.1ns ± 0%     ~     (p=0.429 n=5+4)
Div/mod256/uint256-6      67.6ns ± 0%  67.3ns ± 0%   -0.38%  (p=0.024 n=5+5)
Mod/small/uint256-6       14.8ns ± 0%  12.8ns ± 0%  -13.51%  (p=0.000 n=5+4)
Mod/mod64/uint256-6       59.1ns ± 0%  59.4ns ± 0%   +0.51%  (p=0.016 n=5+4)
Mod/mod128/uint256-6      91.0ns ± 0%  91.5ns ± 0%   +0.55%  (p=0.016 n=5+4)
Mod/mod192/uint256-6      81.7ns ± 0%  82.3ns ± 0%   +0.73%  (p=0.008 n=5+5)
Mod/mod256/uint256-6      69.7ns ± 0%  69.8ns ± 0%     ~     (p=0.167 n=5+5)
AddMod/small/uint256-6    18.7ns ± 2%  16.7ns ± 0%  -10.60%  (p=0.008 n=5+5)
AddMod/mod64/uint256-6     137ns ± 0%    67ns ± 0%  -51.17%  (p=0.000 n=5+4)
AddMod/mod128/uint256-6    212ns ± 0%   107ns ± 1%  -49.34%  (p=0.008 n=5+5)
AddMod/mod192/uint256-6    197ns ± 0%   100ns ± 0%  -49.24%  (p=0.008 n=5+5)
AddMod/mod256/uint256-6    157ns ± 0%    88ns ± 0%  -43.89%  (p=0.029 n=4+4)
MulMod/small/uint256-6    41.0ns ± 0%  37.4ns ± 0%   -8.78%  (p=0.008 n=5+5)
MulMod/mod64/uint256-6     101ns ± 0%   102ns ± 0%   +0.99%  (p=0.008 n=5+5)
MulMod/mod128/uint256-6    174ns ± 0%   176ns ± 0%   +1.15%  (p=0.016 n=4+5)
MulMod/mod192/uint256-6    172ns ± 0%   177ns ± 0%   +2.67%  (p=0.016 n=4+5)
MulMod/mod256/uint256-6    168ns ± 0%   168ns ± 0%     ~     (all equal)
_SDiv/large/uint256-6     90.3ns ± 0%  88.9ns ± 0%   -1.53%  (p=0.000 n=5+4)
```

Still don't understand why e.g. `_Mul/single/uint256-6     15.9ns ± 0%  13.6ns ± 0%     ~     (p=0.079 n=4+5)` is reported as "not affected".