### PR TITLE
Optimize multiplication

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -247,14 +247,32 @@ func umulStep(z, x, y, carry uint64) (uint64, uint64) {
 // umul computes full 256 x 256 -> 512 multiplication.
 func umul(x, y *Int) [8]uint64 {
 	var res [8]uint64
-	for j := 0; j < len(y); j++ {
-		var carry uint64
-		res[j+0], carry = umulStep(res[j+0], x[0], y[j], carry)
-		res[j+1], carry = umulStep(res[j+1], x[1], y[j], carry)
-		res[j+2], carry = umulStep(res[j+2], x[2], y[j], carry)
-		res[j+3], carry = umulStep(res[j+3], x[3], y[j], carry)
-		res[j+4] = carry
-	}
+	var carry uint64
+
+	res[0], carry = umulStep(0, x[0], y[0], 0)
+	res[1], carry = umulStep(0, x[1], y[0], carry)
+	res[2], carry = umulStep(0, x[2], y[0], carry)
+	res[3], carry = umulStep(0, x[3], y[0], carry)
+	res[4] = carry
+
+	res[1], carry = umulStep(res[1], x[0], y[1], 0)
+	res[2], carry = umulStep(res[2], x[1], y[1], carry)
+	res[3], carry = umulStep(res[3], x[2], y[1], carry)
+	res[4], carry = umulStep(res[4], x[3], y[1], carry)
+	res[5] = carry
+
+	res[2], carry = umulStep(res[2], x[0], y[2], 0)
+	res[3], carry = umulStep(res[3], x[1], y[2], carry)
+	res[4], carry = umulStep(res[4], x[2], y[2], carry)
+	res[5], carry = umulStep(res[5], x[3], y[2], carry)
+	res[6] = carry
+
+	res[3], carry = umulStep(res[3], x[0], y[3], 0)
+	res[4], carry = umulStep(res[4], x[1], y[3], carry)
+	res[5], carry = umulStep(res[5], x[2], y[3], carry)
+	res[6], carry = umulStep(res[6], x[3], y[3], carry)
+	res[7] = carry
+
 	return res
 }
 

--- a/uint256.go
+++ b/uint256.go
@@ -247,31 +247,28 @@ func umulStep(z, x, y, carry uint64) (uint64, uint64) {
 // umul computes full 256 x 256 -> 512 multiplication.
 func umul(x, y *Int) [8]uint64 {
 	var res [8]uint64
-	var carry uint64
+	var carry, carry4, carry5, carry6 uint64
+	var res1, res2, res3, res4, res5 uint64
 
 	res[0], carry = umulStep(0, x[0], y[0], 0)
-	res[1], carry = umulStep(0, x[1], y[0], carry)
-	res[2], carry = umulStep(0, x[2], y[0], carry)
-	res[3], carry = umulStep(0, x[3], y[0], carry)
-	res[4] = carry
+	res1, carry = umulStep(0, x[1], y[0], carry)
+	res2, carry = umulStep(0, x[2], y[0], carry)
+	res3, carry4 = umulStep(0, x[3], y[0], carry)
 
-	res[1], carry = umulStep(res[1], x[0], y[1], 0)
-	res[2], carry = umulStep(res[2], x[1], y[1], carry)
-	res[3], carry = umulStep(res[3], x[2], y[1], carry)
-	res[4], carry = umulStep(res[4], x[3], y[1], carry)
-	res[5] = carry
+	res[1], carry = umulStep(res1, x[0], y[1], 0)
+	res2, carry = umulStep(res2, x[1], y[1], carry)
+	res3, carry = umulStep(res3, x[2], y[1], carry)
+	res4, carry5 = umulStep(carry4, x[3], y[1], carry)
 
-	res[2], carry = umulStep(res[2], x[0], y[2], 0)
-	res[3], carry = umulStep(res[3], x[1], y[2], carry)
-	res[4], carry = umulStep(res[4], x[2], y[2], carry)
-	res[5], carry = umulStep(res[5], x[3], y[2], carry)
-	res[6] = carry
+	res[2], carry = umulStep(res2, x[0], y[2], 0)
+	res3, carry = umulStep(res3, x[1], y[2], carry)
+	res4, carry = umulStep(res4, x[2], y[2], carry)
+	res5, carry6 = umulStep(carry5, x[3], y[2], carry)
 
-	res[3], carry = umulStep(res[3], x[0], y[3], 0)
-	res[4], carry = umulStep(res[4], x[1], y[3], carry)
-	res[5], carry = umulStep(res[5], x[2], y[3], carry)
-	res[6], carry = umulStep(res[6], x[3], y[3], carry)
-	res[7] = carry
+	res[3], carry = umulStep(res3, x[0], y[3], 0)
+	res[4], carry = umulStep(res4, x[1], y[3], carry)
+	res[5], carry = umulStep(res5, x[2], y[3], carry)
+	res[6], res[7] = umulStep(carry6, x[3], y[3], carry)
 
 	return res
 }

--- a/uint256.go
+++ b/uint256.go
@@ -239,9 +239,11 @@ func umulStep(z, x, y, carry uint64) (uint64, uint64) {
 
 // umul computes full 256 x 256 -> 512 multiplication.
 func umul(x, y *Int) [8]uint64 {
-	var res [8]uint64
-	var carry, carry4, carry5, carry6 uint64
-	var res1, res2, res3, res4, res5 uint64
+	var (
+		res                           [8]uint64
+		carry, carry4, carry5, carry6 uint64
+		res1, res2, res3, res4, res5  uint64
+	)
 
 	res[0], carry = umulStep(0, x[0], y[0], 0)
 	res1, carry = umulStep(0, x[1], y[0], carry)
@@ -268,9 +270,11 @@ func umul(x, y *Int) [8]uint64 {
 
 // Mul sets z to the sum x*y
 func (z *Int) Mul(x, y *Int) *Int {
-	var res Int
-	var carry uint64
-	var res1, res2, res3 uint64
+	var (
+		res              Int
+		carry            uint64
+		res1, res2, res3 uint64
+	)
 
 	res[0], carry = umulStep(0, x[0], y[0], 0)
 	res1, carry = umulStep(0, x[1], y[0], carry)
@@ -290,9 +294,11 @@ func (z *Int) Mul(x, y *Int) *Int {
 }
 
 func (z *Int) Squared() {
-	var res Int
-	var carry0, carry1, carry2 uint64
-	var res1, res2 uint64
+	var (
+		res                    Int
+		carry0, carry1, carry2 uint64
+		res1, res2             uint64
+	)
 
 	res[0], carry0 = umulStep(0, z[0], z[0], 0)
 	res1, carry0 = umulStep(0, z[0], z[1], carry0)

--- a/uint256.go
+++ b/uint256.go
@@ -831,22 +831,6 @@ func (z *Int) SetOne() *Int {
 	return z
 }
 
-// Lsh shifts z by 1 bit.
-func (z *Int) lshOne() {
-	var (
-		a, b uint64
-	)
-	a = z[0] >> 63
-	b = z[1] >> 63
-
-	z[0] = z[0] << 1
-	z[1] = z[1]<<1 | a
-
-	a = z[2] >> 63
-	z[2] = z[2]<<1 | b
-	z[3] = z[3]<<1 | a
-}
-
 // Lsh sets z = x << n and returns z.
 func (z *Int) Lsh(x *Int, n uint) *Int {
 	// n % 64 == 0

--- a/uint256.go
+++ b/uint256.go
@@ -179,13 +179,6 @@ func (z *Int) AddMod(x, y, m *Int) *Int {
 	return z.Mod(z, m)
 }
 
-// addMiddle128 adds two uint64 integers to the upper part of z
-func addTo128(z []uint64, x0, x1 uint64) {
-	var carry uint64
-	z[0], carry = bits.Add64(z[0], x0, carry)
-	z[1], _ = bits.Add64(z[1], x1, carry)
-}
-
 // PaddedBytes encodes a Int as a 0-padded byte slice. The length
 // of the slice is at least n bytes.
 // Example, z =1, n = 20 => [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]
@@ -319,7 +312,11 @@ func (z *Int) Squared() {
 
 	// c * c
 	beta[3], beta[2] = bits.Mul64(z[1], z[1])
-	addTo128(alfa[2:], beta[2], beta[3])
+
+	var carry uint64
+	alfa[2], carry = bits.Add64(alfa[2], beta[2], 0)
+	alfa[3], _ = bits.Add64(alfa[3], beta[3], carry)
+
 	z.Copy(alfa)
 }
 


### PR DESCRIPTION
1. Fully unroll `umul()` implementation (the first commit does majority of that, the second is small tuning giving small improvement, but affects readability).
2. The use the `umul()` implementation to implement `Mul()`.
3. Also optimize `Squared()`.

```
name                      old time/op  new time/op  delta
_Mul/single/big-6          210ns ± 1%   210ns ± 0%     ~     (p=1.000 n=10+10)
_Mul/single/uint256-6     36.3ns ± 0%  18.0ns ± 0%  -50.37%  (p=0.000 n=10+10)
_Square/single/big-6       207ns ± 0%   207ns ± 1%     ~     (p=0.108 n=9+10)
_Square/single/uint256-6  34.9ns ± 0%  13.7ns ± 0%  -60.71%  (p=0.000 n=9+9)
_Exp/large/big-6          47.5µs ± 1%  47.6µs ± 1%     ~     (p=0.393 n=10+10)
_Exp/large/uint256-6      14.4µs ± 0%   6.8µs ± 0%  -52.91%  (p=0.000 n=10+9)
_Exp/small/big-6          14.2µs ± 0%  14.2µs ± 1%     ~     (p=0.218 n=10+10)
_Exp/small/uint256-6      1.23µs ± 0%  0.57µs ± 0%  -53.43%  (p=0.000 n=10+9)
MulMod/small/uint256-6    85.9ns ± 0%  75.8ns ± 0%  -11.71%  (p=0.000 n=8+10)
MulMod/small/big-6         135ns ± 0%   135ns ± 0%     ~     (all equal)
MulMod/mod64/uint256-6     228ns ± 1%   216ns ± 0%   -5.21%  (p=0.000 n=10+10)
MulMod/mod64/big-6         594ns ± 0%   594ns ± 0%     ~     (p=0.596 n=9+9)
MulMod/mod128/uint256-6    422ns ± 0%   391ns ± 0%   -7.43%  (p=0.000 n=10+8)
MulMod/mod128/big-6       1.11µs ± 0%  1.11µs ± 0%     ~     (p=0.366 n=10+10)
MulMod/mod192/uint256-6    422ns ± 0%   386ns ± 0%   -8.64%  (p=0.000 n=10+8)
MulMod/mod192/big-6       1.02µs ± 0%  1.02µs ± 0%     ~     (p=0.526 n=9+10)
MulMod/mod256/uint256-6    419ns ± 0%   376ns ± 0%  -10.47%  (p=0.000 n=10+10)
MulMod/mod256/big-6        930ns ± 0%   927ns ± 0%   -0.32%  (p=0.000 n=10+10)
```