### PR TITLE
Optimise squared, Mul, and Exp

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -228,22 +228,22 @@ func umul(x, y *Int) [8]uint64 {
 		res1, res2, res3, res4, res5  uint64
 	)
 
-	carry, res[0] = bits.Mul64(x[0], y[0])
-	res1, carry = umulHop(carry, x[1], y[0])
-	res2, carry = umulHop(carry, x[2], y[0])
-	res3, carry4 = umulHop(carry, x[3], y[0])
+	res[0], carry = umulStep(0, x[0], y[0], 0)
+	res1, carry = umulStep(0, x[1], y[0], carry)
+	res2, carry = umulStep(0, x[2], y[0], carry)
+	res3, carry4 = umulStep(0, x[3], y[0], carry)
 
-	res[1], carry = umulHop(res1, x[0], y[1])
+	res[1], carry = umulStep(res1, x[0], y[1], 0)
 	res2, carry = umulStep(res2, x[1], y[1], carry)
 	res3, carry = umulStep(res3, x[2], y[1], carry)
 	res4, carry5 = umulStep(carry4, x[3], y[1], carry)
 
-	res[2], carry = umulHop(res2, x[0], y[2])
+	res[2], carry = umulStep(res2, x[0], y[2], 0)
 	res3, carry = umulStep(res3, x[1], y[2], carry)
 	res4, carry = umulStep(res4, x[2], y[2], carry)
 	res5, carry6 = umulStep(carry5, x[3], y[2], carry)
 
-	res[3], carry = umulHop(res3, x[0], y[3])
+	res[3], carry = umulStep(res3, x[0], y[3], 0)
 	res[4], carry = umulStep(res4, x[1], y[3], carry)
 	res[5], carry = umulStep(res5, x[2], y[3], carry)
 	res[6], res[7] = umulStep(carry6, x[3], y[3], carry)

--- a/uint256.go
+++ b/uint256.go
@@ -228,22 +228,22 @@ func umul(x, y *Int) [8]uint64 {
 		res1, res2, res3, res4, res5  uint64
 	)
 
-	carry, res[0] = umulStep(0, x[0], y[0], 0)
-	carry, res1 = umulStep(0, x[1], y[0], carry)
-	carry, res2 = umulStep(0, x[2], y[0], carry)
-	carry4, res3 = umulStep(0, x[3], y[0], carry)
+	carry, res[0] = bits.Mul64(x[0], y[0])
+	carry, res1 = umulHop(carry, x[1], y[0])
+	carry, res2 = umulHop(carry, x[2], y[0])
+	carry4, res3 = umulHop(carry, x[3], y[0])
 
-	carry, res[1] = umulStep(res1, x[0], y[1], 0)
+	carry, res[1] = umulHop(res1, x[0], y[1])
 	carry, res2 = umulStep(res2, x[1], y[1], carry)
 	carry, res3 = umulStep(res3, x[2], y[1], carry)
 	carry5, res4 = umulStep(carry4, x[3], y[1], carry)
 
-	carry, res[2] = umulStep(res2, x[0], y[2], 0)
+	carry, res[2] = umulHop(res2, x[0], y[2])
 	carry, res3 = umulStep(res3, x[1], y[2], carry)
 	carry, res4 = umulStep(res4, x[2], y[2], carry)
 	carry6, res5 = umulStep(carry5, x[3], y[2], carry)
 
-	carry, res[3] = umulStep(res3, x[0], y[3], 0)
+	carry, res[3] = umulHop(res3, x[0], y[3])
 	carry, res[4] = umulStep(res4, x[1], y[3], carry)
 	carry, res[5] = umulStep(res5, x[2], y[3], carry)
 	res[7], res[6] = umulStep(carry6, x[3], y[3], carry)


### PR DESCRIPTION
```
name                     old time/op  new time/op  delta
Mul/single/uint256-8     8.23ns ± 2%  6.90ns ± 1%  -16.11%  (p=0.000 n=10+9)
Mul/single/big-8         64.5ns ± 1%  62.8ns ± 1%   -2.65%  (p=0.000 n=9+9)
_Exp/large/big-8         23.7µs ± 1%  23.7µs ± 1%     ~     (p=0.896 n=10+10)
_Exp/large/uint256-8     3.34µs ± 1%  2.72µs ± 3%  -18.63%  (p=0.000 n=8+10)
_Exp/small/big-8         7.12µs ± 2%  7.09µs ± 0%     ~     (p=0.345 n=10+9)
_Exp/small/uint256-8      283ns ± 1%   229ns ± 1%  -19.22%  (p=0.000 n=9+10)
Square/single/uint256-8  6.27ns ± 1%  5.14ns ± 1%  -17.91%  (p=0.000 n=10+10)
Square/single/big-8      60.0ns ± 2%  60.0ns ± 1%     ~     (p=0.781 n=10+10)
```