### PR TITLE
optimize + benchmark muloverflow

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -165,6 +165,34 @@ func BenchmarkMul(bench *testing.B) {
 	bench.Run("single/big", benchmarkBig)
 }
 
+func BenchmarkMulOverflow(bench *testing.B) {
+	benchmarkUint256 := func(bench *testing.B) {
+		a := big.NewInt(0).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		b := big.NewInt(0).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		fa, _ := FromBig(a)
+		fb, _ := FromBig(b)
+
+		result := new(Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.MulOverflow(fa, fb)
+		}
+	}
+	benchmarkBig := func(bench *testing.B) {
+		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		b := new(big.Int).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(big.Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			U256(result.Mul(a, b))
+		}
+	}
+
+	bench.Run("single/uint256", benchmarkUint256)
+	bench.Run("single/big", benchmarkBig)
+}
+
 func BenchmarkSquare(bench *testing.B) {
 
 	benchmarkUint256 := func(bench *testing.B) {

--- a/uint256.go
+++ b/uint256.go
@@ -330,15 +330,8 @@ func (z *Int) Mul(x, y *Int) *Int {
 // MulOverflow sets z to the product x*y, and returns whether overflow occurred
 func (z *Int) MulOverflow(x, y *Int) bool {
 	p := umul(x, y)
-	var (
-		pl Int
-		ph Int
-	)
-	copy(pl[:], p[:4])
-	copy(ph[:], p[4:])
-
-	z.Set(&pl)
-	return !ph.IsZero()
+	copy(z[:], p[:4])
+	return (p[4] | p[5] | p[6] | p[7]) != 0
 }
 
 func (z *Int) squared() {


### PR DESCRIPTION
Adds a benchmarks and simplifies/improves `MulOverflow` a bit

```
name                          old time/op    new time/op    delta
MulOverflow/single/uint256-6    25.1ns ± 3%    23.0ns ± 1%  -8.22%  (p=0.016 n=5+4)
MulOverflow/single/big-6        77.0ns ±13%    75.7ns ± 4%    ~     (p=0.937 n=5+5)

name                          old alloc/op   new alloc/op   delta
MulOverflow/single/uint256-6     0.00B          0.00B         ~     (all equal)
MulOverflow/single/big-6         0.00B          0.00B         ~     (all equal)

name                          old allocs/op  new allocs/op  delta
MulOverflow/single/uint256-6      0.00           0.00         ~     (all equal)
MulOverflow/single/big-6          0.00           0.00         ~     (all equal)
```
