### PR TITLE
conversion: add various marshalling methods

### DIFF
--- a/conversion_test.go
+++ b/conversion_test.go
@@ -592,10 +592,9 @@ type marshalTest struct {
 }
 
 type unmarshalTest struct {
-	input        string
-	want         interface{}
-	wantErr      error // if set, decoding must fail on any platform
-	wantErr32bit error // if set, decoding must fail on 32bit platforms (used for Uint tests)
+	input   string
+	want    interface{}
+	wantErr error // if set, decoding must fail on any platform
 }
 
 var (

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -680,6 +680,27 @@ func TestDecode(t *testing.T) {
 			continue
 		}
 	}
+	// Some remaining json-tests
+	type jsonStruct struct {
+		Foo *Int
+	}
+	var jsonDecoded jsonStruct
+	if err := json.Unmarshal([]byte(`{"Foo":0x1}`), &jsonDecoded); err == nil {
+		t.Fatal("Expected error")
+	}
+	if err := json.Unmarshal([]byte(`{"Foo":1}`), &jsonDecoded); err == nil {
+		t.Fatal("Expected error")
+	}
+	if err := json.Unmarshal([]byte(`{"Foo":""}`), &jsonDecoded); err == nil {
+		t.Fatal("Expected error")
+	}
+	if err := json.Unmarshal([]byte(`{"Foo":"0x1"}`), &jsonDecoded); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	} else {
+		if jsonDecoded.Foo.Uint64() != 1 {
+			t.Fatal("Expected 1")
+		}
+	}
 }
 
 func TestEnDecode(t *testing.T) {


### PR DESCRIPTION
This PR adds some more marshalling methods. If we want to replace `big.Int` and `hexutil.Big` with `uint256.Int` in go-ethereum, these methods are needed. 

```
Benchmark_EncodeHex/large/uint256-6             10843225                97.2 ns/op            80 B/op          1 allocs/op
Benchmark_EncodeHex/large/big-6                  6547092               190 ns/op             139 B/op          2 allocs/op
Benchmark_DecodeHex/large/uint256-6              9983671               118 ns/op              32 B/op          1 allocs/op
Benchmark_DecodeHex/large/big-6                 10242964               128 ns/op              32 B/op          1 allocs/op
```