### PR TITLE
Optimize comparison in `Cmp()`

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -294,6 +294,7 @@ func benchmark_Cmp_Big(bench *testing.B) {
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		b1.Cmp(b2)
+		b2.Cmp(b1)
 	}
 }
 func benchmark_Cmp_Bit(bench *testing.B) {
@@ -305,6 +306,7 @@ func benchmark_Cmp_Bit(bench *testing.B) {
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		f.Cmp(f2)
+		f2.Cmp(f)
 	}
 }
 func Benchmark_Cmp(bench *testing.B) {

--- a/uint256.go
+++ b/uint256.go
@@ -788,13 +788,18 @@ func (z *Int) Eq(x *Int) bool {
 //   +1 if z >  x
 //
 func (z *Int) Cmp(x *Int) (r int) {
-	if z.Gt(x) {
-		return 1
-	}
-	if z.Lt(x) {
+	// z < x <=> z - x < 0 i.e. when subtraction overflows.
+	d0, carry := bits.Sub64(z[0], x[0], 0)
+	d1, carry := bits.Sub64(z[1], x[1], carry)
+	d2, carry := bits.Sub64(z[2], x[2], carry)
+	d3, carry := bits.Sub64(z[3], x[3], carry)
+	if carry == 1 {
 		return -1
 	}
-	return 0
+	if d0|d1|d2|d3 == 0 {
+		return 0
+	}
+	return 1
 }
 
 // LtUint64 returns true if z is smaller than n


### PR DESCRIPTION
We can do it with a single comparison. The speed up for the bad case is ~30%.
```
name                   old time/op    new time/op    delta
_Cmp/single/big-8        13.1ns ± 4%    13.1ns ± 2%     ~     (p=0.887 n=10+9)
_Cmp/single/uint256-8    5.40ns ± 3%    4.69ns ± 3%  -13.17%  (p=0.000 n=10+9)

name                   old alloc/op   new alloc/op   delta
_Cmp/single/big-8         0.00B          0.00B          ~     (all equal)
_Cmp/single/uint256-8     0.00B          0.00B          ~     (all equal)

name                   old allocs/op  new allocs/op  delta
_Cmp/single/big-8          0.00           0.00          ~     (all equal)
_Cmp/single/uint256-8      0.00           0.00          ~     (all equal)
```