### PR TITLE
benchmarks: use least non negative residue of the addend for each modulus when testing AddMod

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Guillaume Ballet <gballet@gmail.com>
 Kurkó Mihály <kurkomisi@users.noreply.github.com>
 Paweł Bylica <chfast@gmail.com>
 Yao Zengzeng <yaozengzeng@zju.edu.cn>
+Dag Arne Osvik <daosvik@users.noreply.github.com>


### PR DESCRIPTION
Separate PR for benchmark changes separated out from #86 as requested