### PR TITLE
implement Sqrt()

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -259,6 +259,31 @@ func BenchmarkSquare(bench *testing.B) {
 	bench.Run("single/big", benchmarkBig)
 }
 
+func BenchmarkSqrt(bench *testing.B) {
+	benchmarkUint256 := func(bench *testing.B) {
+		bench.ReportAllocs()
+		a := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Sqrt(a)
+		}
+	}
+	benchmarkBig := func(bench *testing.B) {
+		bench.ReportAllocs()
+		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(big.Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Sqrt(a)
+		}
+	}
+	bench.Run("single/uint256", benchmarkUint256)
+	bench.Run("single/big", benchmarkBig)
+}
+
 func benchmark_And_Big(bench *testing.B) {
 	b1 := big.NewInt(0).SetBytes(hex2Bytes("0123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
 	b2 := big.NewInt(0).SetBytes(hex2Bytes("0123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))

--- a/uint256.go
+++ b/uint256.go
@@ -1217,9 +1217,8 @@ func (z *Int) Sqrt(x *Int) *Int {
 		return z.Set(x)
 	}
 	var (
-		z1   = &Int{1, 0, 0, 0}
-		z2   = &Int{}
-		a, b uint64
+		z1 = &Int{1, 0, 0, 0}
+		z2 = &Int{}
 	)
 	// Start with value known to be too large and repeat "z = ⌊(z + ⌊x/z⌋)/2⌋" until it stops getting smaller.
 	z1 = z1.Lsh(z1, uint(x.BitLen()+1)/2) // must be ≥ √x
@@ -1227,9 +1226,9 @@ func (z *Int) Sqrt(x *Int) *Int {
 		z2 = z2.Div(x, z1)
 		z2 = z2.Add(z2, z1)
 		{ //z2 = z2.Rsh(z2, 1) -- the code below does a 1-bit rsh faster
-			a = z2[3] << 63
+			a := z2[3] << 63
 			z2[3] = z2[3] >> 1
-			b = z2[2] << 63
+			b := z2[2] << 63
 			z2[2] = (z2[2] >> 1) | a
 			a = z2[1] << 63
 			z2[1] = (z2[1] >> 1) | b

--- a/uint256.go
+++ b/uint256.go
@@ -1209,3 +1209,38 @@ func (z *Int) ExtendSign(x, byteNum *Int) *Int {
 	}
 	return z
 }
+
+// Sqrt sets z to ⌊√x⌋, the largest integer such that z² ≤ x, and returns z.
+func (z *Int) Sqrt(x *Int) *Int {
+	// This implementation of Sqrt is based on big.Int (see math/big/nat.go).
+	if x.LtUint64(2) {
+		return z.Set(x)
+	}
+	var (
+		z1   = &Int{1, 0, 0, 0}
+		z2   = &Int{}
+		a, b uint64
+	)
+	// Start with value known to be too large and repeat "z = ⌊(z + ⌊x/z⌋)/2⌋" until it stops getting smaller.
+	z1 = z1.Lsh(z1, uint(x.BitLen()+1)/2) // must be ≥ √x
+	for {
+		z2 = z2.Div(x, z1)
+		z2 = z2.Add(z2, z1)
+		{ //z2 = z2.Rsh(z2, 1) -- the code below does a 1-bit rsh faster
+			a = z2[3] << 63
+			z2[3] = z2[3] >> 1
+			b = z2[2] << 63
+			z2[2] = (z2[2] >> 1) | a
+			a = z2[1] << 63
+			z2[1] = (z2[1] >> 1) | b
+			z2[0] = (z2[0] >> 1) | a
+		}
+		// end of inlined bitshift
+
+		if z2.Cmp(z1) >= 0 {
+			// z1 is answer.
+			return z.Set(z1)
+		}
+		z1, z2 = z2, z1
+	}
+}

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -20,6 +20,9 @@ var (
 	unTestCases = []string{
 		"0",
 		"1",
+		"0x80000000000000000000000000000000",
+		"0x80000000000000010000000000000000",
+		"0x80000000000000000000000000000001",
 		"0x12cbafcee8f60f9f3fa308c90fde8d298772ffea667aa6bc109d5c661e7929a5",
 		"0x8000000000000000000000000000000000000000000000000000000000000000",
 		"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
@@ -352,6 +355,17 @@ func TestRandomSMod(t *testing.T) {
 		},
 		func(b1, b2, b3 *big.Int) {
 			SMod(b1, b2, b3)
+		},
+	)
+}
+
+func TestRandomSqrt(t *testing.T) {
+	testRandomOp(t,
+		func(f1, f2, f3 *Int) {
+			f1.Sqrt(f2)
+		},
+		func(b1, b2, b3 *big.Int) {
+			b1.Sqrt(b2)
 		},
 	)
 }
@@ -1141,6 +1155,7 @@ func TestUnOp(t *testing.T) {
 
 	t.Run("Not", func(t *testing.T) { proc(t, (*Int).Not, (*big.Int).Not) })
 	t.Run("Neg", func(t *testing.T) { proc(t, (*Int).Neg, (*big.Int).Neg) })
+	t.Run("Sqrt", func(t *testing.T) { proc(t, (*Int).Sqrt, (*big.Int).Sqrt) })
 }
 
 func TestBinOp(t *testing.T) {


### PR DESCRIPTION
This PR implements `Sqrt`, and closes #100. 

```
BenchmarkSqrt/single/uint256-6           1958528               603.8 ns/op             0 B/op          0 allocs/op
BenchmarkSqrt/single/uint256-6           1942036               667.9 ns/op             0 B/op          0 allocs/op
BenchmarkSqrt/single/uint256-6           1999359               607.8 ns/op             0 B/op          0 allocs/op
BenchmarkSqrt/single/uint256-6           1914327               587.4 ns/op             0 B/op          0 allocs/op
BenchmarkSqrt/single/uint256-6           2010532               610.4 ns/op             0 B/op          0 allocs/op
BenchmarkSqrt/single/big-6                539826              4824 ns/op             528 B/op          7 allocs/op
BenchmarkSqrt/single/big-6                585172              3554 ns/op             528 B/op          7 allocs/op
BenchmarkSqrt/single/big-6                353688              3529 ns/op             528 B/op          7 allocs/op
BenchmarkSqrt/single/big-6                579885              4223 ns/op             528 B/op          7 allocs/op
BenchmarkSqrt/single/big-6                625279              3426 ns/op             528 B/op          7 allocs/op
```