### PR TITLE
Add Muldiv()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,5 @@ Kurkó Mihály <kurkomisi@users.noreply.github.com>
 Paweł Bylica <chfast@gmail.com>
 Yao Zengzeng <yaozengzeng@zju.edu.cn>
 Dag Arne Osvik <daosvik@users.noreply.github.com>
+Thanee Charattrakool <planxthanee@gmail.com>
+

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -843,33 +843,41 @@ func Benchmark_DecodeHex(b *testing.B) {
 	b.Run("large/big", func(b *testing.B) { hexDecodeBig(b, &big256Samples) })
 }
 
-func BenchmarkMulDivOverflow(bench *testing.B) {
+func BenchmarkMulDivOverflow(b *testing.B) {
+	benchmarkUint256 := func(b *testing.B, factorsSamples, muldivSamples *[numSamples]Int) {
+		iter := (b.N + numSamples - 1) / numSamples
 
-	//TODO: use samples
+		for j := 0; j < numSamples; j++ {
+			x := factorsSamples[j]
 
-	benchmarkUint256 := func(bench *testing.B) {
-		fa := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-		fb := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-		fc := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-
-		result := new(Int)
-		bench.ResetTimer()
-		for i := 0; i < bench.N; i++ {
-			result.MulDivOverflow(fa, fb, fc)
-		}
-	}
-	benchmarkBig := func(bench *testing.B) {
-		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-		b := new(big.Int).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-		c := new(big.Int).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
-
-		result := new(big.Int)
-		bench.ResetTimer()
-		for i := 0; i < bench.N; i++ {
-			U256(result.Div(result.Mul(a, b), c))
+			for i := 0; i < iter; i++ {
+				x.MulDivOverflow(&x, &factorsSamples[j], &muldivSamples[j])
+			}
 		}
 	}
 
-	bench.Run("single/uint256", benchmarkUint256)
-	bench.Run("single/big", benchmarkBig)
+	benchmarkBig := func(b *testing.B, factorsSamples, muldivSamples *[numSamples]big.Int) {
+		iter := (b.N + numSamples - 1) / numSamples
+
+		for j := 0; j < numSamples; j++ {
+			x := factorsSamples[j]
+
+			for i := 0; i < iter; i++ {
+				x.Mul(&x, &factorsSamples[j])
+				x.Mod(&x, &muldivSamples[j])
+			}
+		}
+	}
+
+	b.Run("small/uint256", func(b *testing.B) { benchmarkUint256(b, &int32SamplesLt, &int32Samples) })
+	b.Run("div64/uint256", func(b *testing.B) { benchmarkUint256(b, &int64SamplesLt, &int64Samples) })
+	b.Run("div128/uint256", func(b *testing.B) { benchmarkUint256(b, &int128SamplesLt, &int128Samples) })
+	b.Run("div192/uint256", func(b *testing.B) { benchmarkUint256(b, &int192SamplesLt, &int192Samples) })
+	b.Run("div256/uint256", func(b *testing.B) { benchmarkUint256(b, &int256SamplesLt, &int256Samples) })
+	b.Run("small/big", func(b *testing.B) { benchmarkBig(b, &big32SamplesLt, &big32Samples) })
+	b.Run("div64/big", func(b *testing.B) { benchmarkBig(b, &big64SamplesLt, &big64Samples) })
+	b.Run("div128/big", func(b *testing.B) { benchmarkBig(b, &big128SamplesLt, &big128Samples) })
+	b.Run("div192/big", func(b *testing.B) { benchmarkBig(b, &big192SamplesLt, &big192Samples) })
+	b.Run("div256/big", func(b *testing.B) { benchmarkBig(b, &big256SamplesLt, &big256Samples) })
+
 }

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -842,3 +842,34 @@ func Benchmark_DecodeHex(b *testing.B) {
 	b.Run("large/uint256", func(b *testing.B) { hexDecodeU256(b, &int256Samples) })
 	b.Run("large/big", func(b *testing.B) { hexDecodeBig(b, &big256Samples) })
 }
+
+func BenchmarkMulDivOverflow(bench *testing.B) {
+
+	//TODO: use samples
+
+	benchmarkUint256 := func(bench *testing.B) {
+		fa := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		fb := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		fc := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.MulDivOverflow(fa, fb, fc)
+		}
+	}
+	benchmarkBig := func(bench *testing.B) {
+		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		b := new(big.Int).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+		c := new(big.Int).SetBytes(hex2Bytes("f123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(big.Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			U256(result.Div(result.Mul(a, b), c))
+		}
+	}
+
+	bench.Run("single/uint256", benchmarkUint256)
+	bench.Run("single/big", benchmarkBig)
+}

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -259,6 +259,31 @@ func BenchmarkSquare(bench *testing.B) {
 	bench.Run("single/big", benchmarkBig)
 }
 
+func BenchmarkSqrt(bench *testing.B) {
+	benchmarkUint256 := func(bench *testing.B) {
+		bench.ReportAllocs()
+		a := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Sqrt(a)
+		}
+	}
+	benchmarkBig := func(bench *testing.B) {
+		bench.ReportAllocs()
+		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(big.Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Sqrt(a)
+		}
+	}
+	bench.Run("single/uint256", benchmarkUint256)
+	bench.Run("single/big", benchmarkBig)
+}
+
 func benchmark_And_Big(bench *testing.B) {
 	b1 := big.NewInt(0).SetBytes(hex2Bytes("0123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
 	b2 := big.NewInt(0).SetBytes(hex2Bytes("0123456789abcdefaaaaaa9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -864,7 +864,7 @@ func BenchmarkMulDivOverflow(b *testing.B) {
 
 			for i := 0; i < iter; i++ {
 				x.Mul(&x, &factorsSamples[j])
-				x.Mod(&x, &muldivSamples[j])
+				x.Div(&x, &muldivSamples[j])
 			}
 		}
 	}

--- a/fuzz.go
+++ b/fuzz.go
@@ -215,7 +215,7 @@ func Fuzz(data []byte) int {
 		return fuzzTernaryOp(data) // needs 96 byte
 	}
 	// Too large input
-	return 0
+	return -1
 }
 
 func fuzzUnaryOp(data []byte) int {

--- a/fuzz.go
+++ b/fuzz.go
@@ -299,7 +299,7 @@ func fuzzTernaryOp(data []byte) int {
 	{ // addMod
 		checkThreeArgOp(intAddMod, bigAddMod, x, y, z)
 	}
-	{ // addMod
+	{ // mulDiv
 		checkThreeArgOp(intMulDiv, bigMulDiv, x, y, z)
 	}
 	return 1

--- a/fuzz.go
+++ b/fuzz.go
@@ -205,20 +205,17 @@ func checkThreeArgOp(op opThreeArgFunc, bigOp bigThreeArgFunc, x, y, z Int) {
 func Fuzz(data []byte) int {
 	if len(data) < 32 {
 		return 0
-	} else {
-
-		return fuzzUnaryOp(data)
 	}
-
-	switch len(data) {
-	case 32:
-		return fuzzUnaryOp(data)
-	case 64:
-		return fuzzBinaryOp(data)
-	case 96:
-		return fuzzTernaryOp(data)
+	switch {
+	case len(data) < 64:
+		return fuzzUnaryOp(data) // needs 32 byte
+	case len(data) < 96:
+		return fuzzBinaryOp(data) // needs 64 byte
+	case len(data) < 128:
+		return fuzzTernaryOp(data) // needs 96 byte
 	}
-	return -1
+	// Too large input
+	return 0
 }
 
 func fuzzUnaryOp(data []byte) int {
@@ -277,6 +274,16 @@ func intAddMod(f1, f2, f3, f4 *Int) *Int {
 	return f1.AddMod(f2, f3, f4)
 }
 
+func bigMulDiv(b1, b2, b3, b4 *big.Int) *big.Int {
+	b1.Mul(b2, b3)
+	return b1.Div(b1, b4)
+}
+
+func intMulDiv(f1, f2, f3, f4 *Int) *Int {
+	f1.MulDivOverflow(f2, f3, f4)
+	return f1
+}
+
 func fuzzTernaryOp(data []byte) int {
 	var x, y, z Int
 	x.SetBytes(data[:32])
@@ -291,6 +298,9 @@ func fuzzTernaryOp(data []byte) int {
 	}
 	{ // addMod
 		checkThreeArgOp(intAddMod, bigAddMod, x, y, z)
+	}
+	{ // addMod
+		checkThreeArgOp(intMulDiv, bigMulDiv, x, y, z)
 	}
 	return 1
 }

--- a/oss-fuzz.sh
+++ b/oss-fuzz.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -eu
+compile_go_fuzzer github.com/holiman/uint256  Fuzz      uint256Fuzz

--- a/uint256.go
+++ b/uint256.go
@@ -686,19 +686,6 @@ func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	}
 	p := umul(x, y)
 
-	if (p[4] | p[5] | p[6] | p[7]) == 0 {
-		var pl Int
-		copy(pl[:], p[:4])
-
-		if d.Gt(&pl) {
-			return z.Clear(), false
-		}
-
-		if pl.IsUint64() {
-			return z.SetUint64(pl.Uint64() / d.Uint64()), false
-		}
-	}
-
 	var quot [8]uint64
 	udivrem(quot[:], p[:], d)
 

--- a/uint256.go
+++ b/uint256.go
@@ -1209,3 +1209,37 @@ func (z *Int) ExtendSign(x, byteNum *Int) *Int {
 	}
 	return z
 }
+
+// Sqrt sets z to ⌊√x⌋, the largest integer such that z² ≤ x, and returns z.
+func (z *Int) Sqrt(x *Int) *Int {
+	// This implementation of Sqrt is based on big.Int (see math/big/nat.go).
+	if x.LtUint64(2) {
+		return z.Set(x)
+	}
+	var (
+		z1 = &Int{1, 0, 0, 0}
+		z2 = &Int{}
+	)
+	// Start with value known to be too large and repeat "z = ⌊(z + ⌊x/z⌋)/2⌋" until it stops getting smaller.
+	z1 = z1.Lsh(z1, uint(x.BitLen()+1)/2) // must be ≥ √x
+	for {
+		z2 = z2.Div(x, z1)
+		z2 = z2.Add(z2, z1)
+		{ //z2 = z2.Rsh(z2, 1) -- the code below does a 1-bit rsh faster
+			a := z2[3] << 63
+			z2[3] = z2[3] >> 1
+			b := z2[2] << 63
+			z2[2] = (z2[2] >> 1) | a
+			a = z2[1] << 63
+			z2[1] = (z2[1] >> 1) | b
+			z2[0] = (z2[0] >> 1) | a
+		}
+		// end of inlined bitshift
+
+		if z2.Cmp(z1) >= 0 {
+			// z1 is answer.
+			return z.Set(z1)
+		}
+		z1, z2 = z2, z1
+	}
+}

--- a/uint256.go
+++ b/uint256.go
@@ -681,6 +681,23 @@ func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	}
 	p := umul(x, y)
 
+	if (p[4] | p[5] | p[6] | p[7]) == 0 {
+		var pl Int
+		copy(pl[:], p[:4])
+
+		if d.Gt(&pl) {
+			return z.Clear(), false
+		}
+
+		if pl.Eq(d) {
+			return z.SetOne(), false
+		}
+
+		if pl.IsUint64() {
+			return z.SetUint64(pl.Uint64() / d.Uint64()), false
+		}
+	}
+
 	var quot [8]uint64
 	udivrem(quot[:], p[:], d)
 

--- a/uint256.go
+++ b/uint256.go
@@ -673,9 +673,8 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 	return z.Set(&rem)
 }
 
-// MulDivOverflow
-// TODO: add documentation
-// return (x * y) / d
+// MulDivOverflow calculates (x*y)/d with full precision, returns z and  whether overflow occurred.
+// computes 512-bit multiplication and 256-bit division.
 func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	if x.IsZero() || y.IsZero() || d.IsZero() {
 		return z.Clear(), false

--- a/uint256.go
+++ b/uint256.go
@@ -673,6 +673,35 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 	return z.Set(&rem)
 }
 
+// MulDivOverflow
+// TODO: add documentation
+// return (x * y) / d
+func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
+	if x.IsZero() || y.IsZero() || d.IsZero() {
+		return z.Clear(), false
+	}
+	p := umul(x, y)
+
+	var (
+		pl Int
+		ph Int
+	)
+	copy(pl[:], p[:4])
+	copy(ph[:], p[4:])
+
+	// If the multiplication is within 256 bits use Div().
+	if ph.IsZero() {
+		return z.Div(&pl, d), false
+	}
+
+	var quot [8]uint64
+	udivrem(quot[:], p[:], d)
+
+	copy(z[:], quot[:4])
+
+	return z, (quot[4] | quot[5] | quot[6] | quot[7]) != 0
+}
+
 // Abs interprets x as a two's complement signed number,
 // and sets z to the absolute value
 //   Abs(0)        = 0

--- a/uint256.go
+++ b/uint256.go
@@ -681,13 +681,6 @@ func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	}
 	p := umul(x, y)
 
-	// If the multiplication is within 256 bits use Div().
-	if (p[4] | p[5] | p[6] | p[7]) == 0 {
-		var pl Int
-		copy(pl[:], p[:4])
-		return z.Div(&pl, d), false
-	}
-
 	var quot [8]uint64
 	udivrem(quot[:], p[:], d)
 

--- a/uint256.go
+++ b/uint256.go
@@ -689,10 +689,6 @@ func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 			return z.Clear(), false
 		}
 
-		if pl.Eq(d) {
-			return z.SetOne(), false
-		}
-
 		if pl.IsUint64() {
 			return z.SetUint64(pl.Uint64() / d.Uint64()), false
 		}

--- a/uint256.go
+++ b/uint256.go
@@ -681,15 +681,10 @@ func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	}
 	p := umul(x, y)
 
-	var (
-		pl Int
-		ph Int
-	)
-	copy(pl[:], p[:4])
-	copy(ph[:], p[4:])
-
 	// If the multiplication is within 256 bits use Div().
-	if ph.IsZero() {
+	if (p[4] | p[5] | p[6] | p[7]) == 0 {
+		var pl Int
+		copy(pl[:], p[:4])
 		return z.Div(&pl, d), false
 	}
 

--- a/uint256.go
+++ b/uint256.go
@@ -673,7 +673,7 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 	return z.Set(&rem)
 }
 
-// MulDivOverflow calculates (x*y)/d with full precision, returns z and whether overflow occurred.
+// MulDivOverflow calculates (x*y)/d with full precision, returns z and whether overflow occurred in multiply process (result does not fit to 256-bit).
 // computes 512-bit multiplication and 512 by 256 division.
 func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
 	if x.IsZero() || y.IsZero() || d.IsZero() {

--- a/uint256.go
+++ b/uint256.go
@@ -673,10 +673,10 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 	return z.Set(&rem)
 }
 
-// MulDivOverflow calculates (x*y)/d with full precision, returns z and  whether overflow occurred.
-// computes 512-bit multiplication and 256-bit division.
+// MulDivOverflow calculates (x*y)/d with full precision, returns z and whether overflow occurred.
+// computes 512-bit multiplication and 512 by 256 division.
 func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
-	if x.IsZero() || y.IsZero() || d.IsZero() {
+	if d.IsZero() {
 		return z.Clear(), false
 	}
 	p := umul(x, y)

--- a/uint256.go
+++ b/uint256.go
@@ -676,7 +676,7 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 // MulDivOverflow calculates (x*y)/d with full precision, returns z and whether overflow occurred.
 // computes 512-bit multiplication and 512 by 256 division.
 func (z *Int) MulDivOverflow(x, y, d *Int) (*Int, bool) {
-	if d.IsZero() {
+	if x.IsZero() || y.IsZero() || d.IsZero() {
 		return z.Clear(), false
 	}
 	p := umul(x, y)

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -20,6 +20,9 @@ var (
 	unTestCases = []string{
 		"0",
 		"1",
+		"0x80000000000000000000000000000000",
+		"0x80000000000000010000000000000000",
+		"0x80000000000000000000000000000001",
 		"0x12cbafcee8f60f9f3fa308c90fde8d298772ffea667aa6bc109d5c661e7929a5",
 		"0x8000000000000000000000000000000000000000000000000000000000000000",
 		"0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe",
@@ -352,6 +355,17 @@ func TestRandomSMod(t *testing.T) {
 		},
 		func(b1, b2, b3 *big.Int) {
 			SMod(b1, b2, b3)
+		},
+	)
+}
+
+func TestRandomSqrt(t *testing.T) {
+	testRandomOp(t,
+		func(f1, f2, f3 *Int) {
+			f1.Sqrt(f2)
+		},
+		func(b1, b2, b3 *big.Int) {
+			b1.Sqrt(b2)
 		},
 	)
 }
@@ -1141,6 +1155,7 @@ func TestUnOp(t *testing.T) {
 
 	t.Run("Not", func(t *testing.T) { proc(t, (*Int).Not, (*big.Int).Not) })
 	t.Run("Neg", func(t *testing.T) { proc(t, (*Int).Neg, (*big.Int).Neg) })
+	t.Run("Sqrt", func(t *testing.T) { proc(t, (*Int).Sqrt, (*big.Int).Sqrt) })
 }
 
 func TestBinOp(t *testing.T) {

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -728,6 +728,38 @@ func TestRandomMulMod(t *testing.T) {
 	}
 }
 
+func TestRandomMulModOverflow(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		b1, f1, err := randNums()
+		if err != nil {
+			t.Fatal(err)
+		}
+		b2, f2, err := randNums()
+		if err != nil {
+			t.Fatal(err)
+		}
+		b3, f3, err := randNums()
+		if err != nil {
+			t.Fatal(err)
+		}
+		f1a, f2a, f3a := f1.Clone(), f2.Clone(), f3.Clone()
+
+		_, overflow := f1.MulDivOverflow(f1, f2, f3)
+		if b3.BitLen() == 0 {
+			b1.SetInt64(0)
+		} else {
+			b1.Div(b1.Mul(b1, b2), b3)
+		}
+
+		if err := checkOverflow(b1, f1, overflow); err != nil {
+			t.Fatal(err)
+		}
+		if eq := checkEq(b1, f1); !eq {
+			t.Fatalf("Expected equality:\nf1= %x\nf2= %x\nf3= %x\n[ - ]==\nf= %x\nb= %x\n", f1a, f2a, f3a, f1, b1)
+		}
+	}
+}
+
 func S256(x *big.Int) *big.Int {
 	if x.Cmp(bigtt255) < 0 {
 		return x

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -728,7 +728,7 @@ func TestRandomMulMod(t *testing.T) {
 	}
 }
 
-func TestRandomMulModOverflow(t *testing.T) {
+func TestRandomMulDivOverflow(t *testing.T) {
 	for i := 0; i < 10000; i++ {
 		b1, f1, err := randNums()
 		if err != nil {


### PR DESCRIPTION

`(x * y) / denominator` is the most common case that cannot be calculated with full precision by normal methods `z.Mul(x, y).Div(z, denominator)` 

ex. `(max_uint256 * 2)/10` 
an overflow occurs when you try to calculated by normal methods, but the result is smaller than `max_uint256`.

`MulDivOverflow()` is 512-bit multiplication and 512-bit by 256-bit division.
returns The 256-bit result and overflow occurred. 

inspired and realworld use-case from UniswapV3
[https://github.com/Uniswap/v3-core/blob/main/contracts/libraries/FullMath.sol](url)

```
BenchmarkMulDivOverflow/small/uint256-8         	491599033	         2.297 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div64/uint256-8         	512714014	         2.351 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div128/uint256-8        	488145638	         2.415 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div192/uint256-8        	484725356	         2.457 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div256/uint256-8        	438809512	         2.509 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/small/big-8             	58039941	        20.62 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div64/big-8             	58061472	        20.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div128/big-8            	43477892	        24.84 ns/op	       1 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div192/big-8            	46356553	        24.83 ns/op	       2 B/op	       0 allocs/op
BenchmarkMulDivOverflow/div256/big-8            	40076848	        28.15 ns/op	       4 B/op	       0 allocs/op
```