### PR TITLE
Handle nominator smaller than divisor in udivrem()

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -508,6 +508,11 @@ func udivrem(quot, u []uint64, d *Int) (rem Int) {
 		}
 	}
 
+	if uLen < dLen {
+		copy(rem[:], u)
+		return rem
+	}
+
 	var unStorage [9]uint64
 	un := unStorage[:uLen+1]
 	un[uLen] = u[uLen-1] >> (64 - shift)


### PR DESCRIPTION
I wanted to make `udivrem()` more robust by making it handle the case where nominator is smaller than divisor (currently it will panic weirdly in this case).

I'm testing the change though `TestRandomDiv` and `TestRandomMod` where `divraw` and `modraw` wrappers are provided.

The `modraw` fails a test when a param and result are aliased. I have not been able to figure out the cause of the problem so far.