### PR TITLE
conversion: optimize `Scan()` scientific scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /.idea
+
+
+# go output files
+*.test
+*.out
+*.pb.gz

--- a/conversion.go
+++ b/conversion.go
@@ -570,7 +570,7 @@ func (dst *Int) Scan(src interface{}) error {
 	case []byte:
 		return dst.scanScientificFromString(string(src))
 	}
-	return fmt.Errorf("cannot scan %T", src)
+	return errors.New("unsupported type")
 }
 
 func (dst *Int) scanScientificFromString(src string) error {

--- a/conversion.go
+++ b/conversion.go
@@ -592,12 +592,12 @@ func (dst *Int) scanScientificFromString(src string) error {
 	if err := exp.SetFromDecimal(src[(idx + 1):]); err != nil {
 		return err
 	}
-	if !exp.IsUint64() || exp.Uint64() > uint64(len(twoPow256Sub1)) {
+	// 10**78 is larger than 2**256
+	if !exp.IsUint64() || exp.GtUint64(77) {
 		return ErrBig256Range
 	}
 	exp.Exp(NewInt(10), exp)
-	_, overflow := dst.MulOverflow(dst, exp)
-	if overflow {
+	if _, overflow := dst.MulOverflow(dst, exp); overflow {
 		return ErrBig256Range
 	}
 	return nil

--- a/conversion.go
+++ b/conversion.go
@@ -592,8 +592,7 @@ func (dst *Int) scanScientificFromString(src string) error {
 	if err := exp.SetFromDecimal(src[(idx + 1):]); err != nil {
 		return err
 	}
-	// 10**78 is larger than 2**256
-	if !exp.IsUint64() || exp.GtUint64(77) {
+	if exp.GtUint64(77) { // 10**78 is larger than 2**256
 		return ErrBig256Range
 	}
 	exp.Exp(NewInt(10), exp)

--- a/conversion.go
+++ b/conversion.go
@@ -578,16 +578,9 @@ func (dst *Int) scanScientificFromString(src string) error {
 		dst.Clear()
 		return nil
 	}
-	idx := strings.Index(src, "e")
-	if idx == 0 {
-		return nil
-	}
+	idx := strings.IndexByte(src, 'e')
 	if idx == -1 {
 		return dst.SetFromDecimal(src)
-	}
-	// ends in e, assume e0
-	if idx == len(src)-1 {
-		return dst.SetFromDecimal(src[:idx])
 	}
 	if err := dst.SetFromDecimal(src[:idx]); err != nil {
 		return err

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -96,6 +96,10 @@ func TestScanScientific(t *testing.T) {
 			exp: intsub1,
 		},
 		{
+			in:  twoPow256Sub1 + "e",
+			exp: intsub1,
+		},
+		{
 			in:  "1e25352",
 			err: ErrBig256Range.Error(),
 		},
@@ -164,6 +168,40 @@ func TestToBig(t *testing.T) {
 		expected.Lsh(expected, i)
 		if b.Cmp(expected) != 0 {
 			t.Fatalf("expected %x, got %x", expected, b)
+		}
+	}
+}
+
+func BenchmarkScanScientific(b *testing.B) {
+	intsub1 := new(Int)
+	_ = intsub1.fromDecimal(twoPow256Sub1)
+	cases := []struct {
+		in  string
+		exp *Int
+		err string
+	}{
+		{
+			in:  "14e30",
+			exp: new(Int).Mul(NewInt(14), new(Int).Exp(NewInt(10), NewInt(30))),
+		},
+		{
+			in:  "1455522523e31",
+			exp: new(Int).Mul(NewInt(1455522523), new(Int).Exp(NewInt(10), NewInt(31))),
+		},
+		{
+			in:  twoPow256Sub1 + "e0",
+			exp: intsub1,
+		},
+		{
+			in:  "1e00000000000000000",
+			exp: NewInt(1),
+		},
+	}
+	i := new(Int)
+	b.ResetTimer()
+	for idx := 0; idx < b.N; idx++ {
+		for _, v := range cases {
+			i.Scan(v.in)
 		}
 	}
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -84,6 +84,18 @@ func TestScanScientific(t *testing.T) {
 		err string
 	}{
 		{
+			in:  "e30",
+			err: "EOF",
+		},
+		{
+			in:  "30e",
+			err: "EOF",
+		},
+		{
+			in:  twoPow256Sub1 + "e",
+			err: "EOF",
+		},
+		{
 			in:  "14e30",
 			exp: new(Int).Mul(NewInt(14), new(Int).Exp(NewInt(10), NewInt(30))),
 		},
@@ -93,10 +105,6 @@ func TestScanScientific(t *testing.T) {
 		},
 		{
 			in:  twoPow256Sub1 + "e0",
-			exp: intsub1,
-		},
-		{
-			in:  twoPow256Sub1 + "e",
 			exp: intsub1,
 		},
 		{

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -84,6 +84,10 @@ func TestScanScientific(t *testing.T) {
 		err string
 	}{
 		{
+			in:  "",
+			exp: new(Int),
+		},
+		{
 			in:  "e30",
 			err: "EOF",
 		},

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -201,7 +201,7 @@ func BenchmarkScanScientific(b *testing.B) {
 	b.ResetTimer()
 	for idx := 0; idx < b.N; idx++ {
 		for _, v := range cases {
-			i.Scan(v.in)
+			_ = i.Scan(v.in)
 		}
 	}
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -99,6 +99,14 @@ func TestScanScientific(t *testing.T) {
 			in:  "14e30",
 			exp: new(Int).Mul(NewInt(14), new(Int).Exp(NewInt(10), NewInt(30))),
 		},
+		{ // 0xdd15fe86affad800000000000000000000000000000000000000000000000000
+			in:  "1e77",
+			exp: new(Int).Mul(NewInt(1), new(Int).Exp(NewInt(10), NewInt(77))),
+		},
+		{ // 0x8a2dbf142dfcc8000000000000000000000000000000000000000000000000000
+			in:  "1e78",
+			err: ErrBig256Range.Error(),
+		},
 		{
 			in:  "1455522523e31",
 			exp: new(Int).Mul(NewInt(1455522523), new(Int).Exp(NewInt(10), NewInt(31))),


### PR DESCRIPTION
this pr has the following:

1. the call to strings.SplitN in my original implementation is replaced with Index, and the function is changed to avoid the extra allocation
2. makes the []byte variant properly parse scientific notation. 
3. adds pprof debug output to gitignore
4. adds benchmark to bench the scan function
