### PR TITLE
add `MustFromBig` for nicer struct initialization

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -66,6 +66,17 @@ func FromBig(b *big.Int) (*Int, bool) {
 	return z, overflow
 }
 
+// MustFromBig is a convenience-constructor from big.Int.
+// Returns a new Int and panics if overflow occurred.
+func MustFromBig(b *big.Int) *Int {
+	z := &Int{}
+	overflow := z.SetFromBig(b)
+	if overflow {
+		panic("overflow")
+	}
+	return z
+}
+
 // SetFromHex sets z from the given string, interpreted as a hexadecimal number.
 // OBS! This method is _not_ strictly identical to the (*big.Int).SetString(..., 16) method.
 // Notable differences:

--- a/conversion.go
+++ b/conversion.go
@@ -70,7 +70,7 @@ func FromBig(b *big.Int) (*Int, bool) {
 // Returns a new Int and panics if overflow occurred.
 func MustFromBig(b *big.Int) *Int {
 	z := &Int{}
-	if overflow := z.SetFromBig(b); overflow {
+	if z.SetFromBig(b) {
 		panic("overflow")
 	}
 	return z

--- a/conversion.go
+++ b/conversion.go
@@ -70,7 +70,7 @@ func FromBig(b *big.Int) (*Int, bool) {
 // Returns a new Int and panics if overflow occurred.
 func MustFromBig(b *big.Int) *Int {
 	z := &Int{}
-	if overflow := z.SetFromBig(b) {
+	if overflow := z.SetFromBig(b); overflow {
 		panic("overflow")
 	}
 	return z

--- a/conversion.go
+++ b/conversion.go
@@ -70,8 +70,7 @@ func FromBig(b *big.Int) (*Int, bool) {
 // Returns a new Int and panics if overflow occurred.
 func MustFromBig(b *big.Int) *Int {
 	z := &Int{}
-	overflow := z.SetFromBig(b)
-	if overflow {
+	if overflow := z.SetFromBig(b) {
 		panic("overflow")
 	}
 	return z


### PR DESCRIPTION
This PR allows the second form (last two lines) along side the current form (first two lines) of initializing new ints from bigs.

```go
var (
	costCap, _   = uint256.FromBig(item.Tx.Cost())
	gasTipCap, _ = uint256.FromBig(item.Tx.GasTipCap())
)
meta := &blobTxMeta{
	id:            id,
	size:          size,
	nonce:         item.Tx.Nonce(),
	costCap:       costCap,
	gasTipCap:     gasTipCap,
	gasFeeCap:     uint256.MustFromBig(item.Tx.GasFeeCap()),
	blobGasFeeCap: uint256.MustFromBig(item.Tx.BlobGasFeeCap()),
}
```

Panics can only be captured when a goroutine is unwinding, hence why the messy construct in the tests. Also, it would have been a tad cleaner to wait on the panic with `sync.WaitGroup` vs a channel, but the channel approach introducing a dependency on `sync`.