### PR TITLE
conversion: add `PrettyDec`, optimize `Dec`, add benchmarks and fuzzing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,7 +44,8 @@ jobs:
       - run:
           name: "Fuzzing"
           command: |
-            GOCACHE=/home/circleci/project/corpus-v3 go test . -run - -fuzz . -fuzztime 1m
+            GOCACHE=/home/circleci/project/corpus-v3 go test . -run - -fuzz FuzzBase10StringCompare -fuzztime 30s
+            GOCACHE=/home/circleci/project/corpus-v3 go test . -run - -fuzz FuzzDecimal -fuzztime 30s
       - save_cache:
           key: corpus-v3-{{ epoch }}
           paths:

--- a/conversion.go
+++ b/conversion.go
@@ -667,7 +667,7 @@ func (dst *Int) scanScientificFromString(src string) error {
 // In MariaDB/MySQL, this will work with the Numeric/Decimal types up to 65 digits, however any more and you should use either VarChar or Char(79)
 // In SqLite, use TEXT
 func (src *Int) Value() (driver.Value, error) {
-	return src.ToBig().String(), nil
+	return src.Dec(), nil
 }
 
 var (

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1213,18 +1213,21 @@ func TestEnDecode(t *testing.T) {
 		if got, _ := intSample.Value(); wantDec != got.(string) {
 			t.Fatalf("test %d #4, got %v, exp %v", i, got, wantHex)
 		}
+		if got := intSample.Dec(); wantDec != got {
+			t.Fatalf("test %d #5, got %v, exp %v", i, got, wantHex)
+		}
 		{ // Json
 			jsonEncoded, err := json.Marshal(&jsonStruct{&intSample})
 			if err != nil {
-				t.Fatalf("test %d #4, err: %v", i, err)
+				t.Fatalf("test %d #6, err: %v", i, err)
 			}
 			var jsonDecoded jsonStruct
 			err = json.Unmarshal(jsonEncoded, &jsonDecoded)
 			if err != nil {
-				t.Fatalf("test %d #5, err: %v", i, err)
+				t.Fatalf("test %d #7, err: %v", i, err)
 			}
 			if jsonDecoded.Foo.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #6, got %v, exp %v", i, jsonDecoded.Foo, intSample)
+				t.Fatalf("test %d #8, got %v, exp %v", i, jsonDecoded.Foo, intSample)
 			}
 		}
 		// Decoding
@@ -1233,67 +1236,67 @@ func TestEnDecode(t *testing.T) {
 		decoded, err := FromHex(wantHex)
 		{
 			if err != nil {
-				t.Fatalf("test %d #5, err: %v", i, err)
+				t.Fatalf("test %d #9, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #6, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #10, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// z.SetFromHex
 		err = decoded.SetFromHex(wantHex)
 		{
 			if err != nil {
-				t.Fatalf("test %d #5, err: %v", i, err)
+				t.Fatalf("test %d #11, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #6, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #12, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// UnmarshalText
 		decoded = new(Int)
 		{
 			if err := decoded.UnmarshalText([]byte(wantHex)); err != nil {
-				t.Fatalf("test %d #7, err: %v", i, err)
+				t.Fatalf("test %d #13, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #8, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #14, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// FromDecimal
 		decoded, err = FromDecimal(wantDec)
 		{
 			if err != nil {
-				t.Fatalf("test %d #9, err: %v", i, err)
+				t.Fatalf("test %d #15, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #10, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #16, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// Scan w string
 		err = decoded.Scan(wantDec)
 		{
 			if err != nil {
-				t.Fatalf("test %d #9, err: %v", i, err)
+				t.Fatalf("test %d #17, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #10, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #18, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// Scan w byte slice
 		err = decoded.Scan([]byte(wantDec))
 		{
 			if err != nil {
-				t.Fatalf("test %d #9, err: %v", i, err)
+				t.Fatalf("test %d #19, err: %v", i, err)
 			}
 			if decoded.Cmp(&intSample) != 0 {
-				t.Fatalf("test %d #10, got %v, exp %v", i, decoded, intSample)
+				t.Fatalf("test %d #20, got %v, exp %v", i, decoded, intSample)
 			}
 		}
 		// Scan with neither string nor byte
 		err = decoded.Scan(5)
 		{
 			if err == nil {
-				t.Fatalf("test %d #11, want error", i)
+				t.Fatalf("test %d #21, want error", i)
 			}
 		}
 	}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1335,6 +1335,19 @@ func TestDecimal(t *testing.T) {
 	}
 }
 
+func TestSingleDecimal(t *testing.T) {
+	a, _ := FromDecimal("18446744073709551616")
+	want := a.ToBig().Text(10)
+	have := a.Dec()
+	if have != want {
+		t.Fatalf("want '%v' have '%v', \n", want, have)
+	}
+	// Op must not modify the original
+	if have := a.Dec(); have != want {
+		t.Fatalf("second test: want '%v' have '%v', \n", want, have)
+	}
+}
+
 func TestPrettyDecimal(t *testing.T) {
 	// prettyFmtBigInt formats n with thousand separators.
 	prettyFmtBigInt := func(n *big.Int) string {

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1333,18 +1333,9 @@ func TestDecimal(t *testing.T) {
 			t.Errorf("second test: want '%v' have '%v', \n", want, have)
 		}
 	}
-}
-
-func TestSingleDecimal(t *testing.T) {
-	a, _ := FromDecimal("18446744073709551616")
-	want := a.ToBig().Text(10)
-	have := a.Dec()
-	if have != want {
-		t.Fatalf("want '%v' have '%v', \n", want, have)
-	}
-	// Op must not modify the original
-	if have := a.Dec(); have != want {
-		t.Fatalf("second test: want '%v' have '%v', \n", want, have)
+	// test zero-case
+	if have, want := new(Int).Dec(), new(big.Int).Text(10); have != want {
+		t.Errorf("have '%v', want '%v'", have, want)
 	}
 }
 
@@ -1383,13 +1374,16 @@ func TestPrettyDecimal(t *testing.T) {
 		have := a.PrettyDec(',')
 		want := prettyFmtBigInt(a.ToBig())
 		if have != want {
-			t.Fatalf("%d: have '%v', want '%v'", i, have, want)
+			t.Errorf("%d: have '%v', want '%v'", i, have, want)
 		}
 		// Op must not modify the original
 		if have := a.PrettyDec(','); have != want {
 			t.Errorf("second test: want '%v' have '%v', \n", want, have)
 		}
-
+	}
+	// test zero-case
+	if have, want := new(Int).PrettyDec(','), prettyFmtBigInt(new(big.Int)); have != want {
+		t.Errorf("have '%v', want '%v'", have, want)
 	}
 }
 

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1366,7 +1366,7 @@ func TestPrettyDecimal(t *testing.T) {
 		have := a.PrettyDec(',')
 		want := prettyFmtBigInt(a.ToBig())
 		if have != want {
-			t.Fatalf("have %v, want %v", have, want)
+			t.Fatalf("%d: have '%v', want '%v'", i, have, want)
 		}
 	}
 }

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1328,6 +1328,10 @@ func TestDecimal(t *testing.T) {
 		if have != want {
 			t.Errorf("want '%v' have '%v', \n", want, have)
 		}
+		// Op must not modify the original
+		if have := a.Dec(); have != want {
+			t.Errorf("second test: want '%v' have '%v', \n", want, have)
+		}
 	}
 }
 
@@ -1368,6 +1372,11 @@ func TestPrettyDecimal(t *testing.T) {
 		if have != want {
 			t.Fatalf("%d: have '%v', want '%v'", i, have, want)
 		}
+		// Op must not modify the original
+		if have := a.PrettyDec(','); have != want {
+			t.Errorf("second test: want '%v' have '%v', \n", want, have)
+		}
+
 	}
 }
 

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1337,6 +1337,20 @@ func TestDecimal(t *testing.T) {
 	if have, want := new(Int).Dec(), new(big.Int).Text(10); have != want {
 		t.Errorf("have '%v', want '%v'", have, want)
 	}
+	{ // max
+		max, _ := FromHex("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+		maxb, _ := new(big.Int).SetString("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 0)
+		if have, want := max.Dec(), maxb.Text(10); have != want {
+			t.Errorf("have '%v', want '%v'", have, want)
+		}
+	}
+	{
+		max, _ := FromDecimal("29999999999999999999")
+		maxb, _ := new(big.Int).SetString("29999999999999999999", 0)
+		if have, want := max.Dec(), maxb.Text(10); have != want {
+			t.Errorf("have '%v', want '%v'", have, want)
+		}
+	}
 }
 
 func TestPrettyDecimal(t *testing.T) {

--- a/decimal.go
+++ b/decimal.go
@@ -51,7 +51,7 @@ func (z *Int) Dec() string {
 		// Convert the R to ascii representation
 		buf = strconv.AppendUint(buf[:0], rem.Uint64(), 10)
 		// Copy in the ascii digits
-		copy(out[pos-len(buf):], buf[:])
+		copy(out[pos-len(buf):], buf)
 		if y.IsZero() {
 			break
 		}
@@ -85,7 +85,7 @@ func (z *Int) PrettyDec(separator byte) string {
 		buf = strconv.AppendUint(buf[:0], rem.Uint64(), 10)
 		for j := len(buf) - 1; j >= 0; j-- {
 			if comma == 3 {
-				out[pos] = ','
+				out[pos] = separator
 				pos--
 				comma = 0
 			}
@@ -99,7 +99,7 @@ func (z *Int) PrettyDec(separator byte) string {
 		// Need to do zero-padding if we have more iterations coming
 		for j := 0; j < 19-len(buf); j++ {
 			if comma == 3 {
-				out[pos] = ','
+				out[pos] = separator
 				pos--
 				comma = 0
 			}

--- a/decimal.go
+++ b/decimal.go
@@ -6,19 +6,32 @@ package uint256
 
 import (
 	"io"
-	"math"
 	"strconv"
 )
 
 const twoPow256Sub1 = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
 
 // Dec returns the decimal representation of z.
-// OBS: This method is not optimized, and uses big.Int-conversion under the hood (TODO!)
 func (z *Int) Dec() string {
-	if z.LtUint64(math.MaxInt64) {
-		return strconv.FormatInt(int64(z.Uint64()), 10)
+	if z.IsZero() {
+		return "0"
 	}
-	return z.ToBig().Text(10)
+	var (
+		ten          = NewInt(10)
+		y            = &(*z)
+		chars        = []byte("0123456789")
+		out   []byte = make([]byte, 0, 78)
+	)
+	for !y.IsZero() {
+		var quot Int
+		rem := udivrem(quot[:], y[:], ten)
+		y.Set(&quot)
+		out = append(out, chars[rem.Uint64()%10])
+	}
+	for i := 0; i < len(out)/2; i++ {
+		out[i], out[len(out)-1-i] = out[len(out)-1-i], out[i]
+	}
+	return string(out)
 }
 
 // PrettyDec returns the decimal representation of z, with thousands-separators.

--- a/decimal.go
+++ b/decimal.go
@@ -17,10 +17,10 @@ func (z *Int) Dec() string {
 		return "0"
 	}
 	var (
-		ten          = NewInt(10)
-		y            = &(*z)
-		chars        = []byte("0123456789")
-		out   []byte = make([]byte, 0, 78)
+		ten   = NewInt(10)
+		y     = new(Int).Set(z)
+		chars = []byte("0123456789")
+		out   = make([]byte, 0, 78)
 	)
 	for !y.IsZero() {
 		var quot Int
@@ -35,24 +35,34 @@ func (z *Int) Dec() string {
 }
 
 // PrettyDec returns the decimal representation of z, with thousands-separators.
-// OBS: This method is not optimized, and uses big.Int-conversion under the hood (TODO!)
 func (z *Int) PrettyDec(separator byte) string {
+	if z.IsZero() {
+		return "0"
+	}
+	// Largest string has 103 characters:
+	// 115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457,584,007,913,129,639,935
 	var (
-		text  = z.Dec()
-		buf   = make([]byte, len(text)+len(text)/3)
-		comma = 0
-		i     = len(buf) - 1
+		ten   = NewInt(10)
+		y     = new(Int).Set(z)
+		chars = []byte("0123456789")
+		out   = make([]byte, 0, 103)
+		comma int
 	)
-	for j := len(text) - 1; j >= 0; j, i = j-1, i-1 {
+	for !y.IsZero() {
 		if comma == 3 {
-			buf[i] = separator
-			i--
+			out = append(out, separator)
 			comma = 0
 		}
-		buf[i] = text[j]
+		var quot Int
+		rem := udivrem(quot[:], y[:], ten)
+		y.Set(&quot)
+		out = append(out, chars[rem.Uint64()%10])
 		comma++
 	}
-	return string(buf[i+1:])
+	for i := 0; i < len(out)/2; i++ {
+		out[i], out[len(out)-1-i] = out[len(out)-1-i], out[i]
+	}
+	return string(out)
 }
 
 // FromDecimal is a convenience-constructor to create an Int from a

--- a/decimal.go
+++ b/decimal.go
@@ -19,17 +19,21 @@ func (z *Int) Dec() string {
 	if z.IsUint64() {
 		return strconv.FormatUint(z.Uint64(), 10)
 	}
-	// The max uint64 value is 18446744073709551615, thus the largest
-	// base10 power-of-ten number is 10000000000000000000.
-	// When we do a QuoRem using that number, the remainder that we
+	// The max uint64 value being 18446744073709551615, the largest
+	// power-of-ten below that is 10000000000000000000.
+	// When we do a DivMod using that number, the remainder that we
 	// get back is the lower part of the output.
-	// Example using 100
+	//
+	// The ascii-output of remainder will never exceed 19 bytes (since it will be
+	// below 10000000000000000000).
+	//
+	// Algorithm example using 100 as divisor
 	//
 	// 12345 % 100 = 45   (rem)
 	// 12345 / 100 = 123  (quo)
 	// -> output '45', continue iterate on 123
 	var (
-		divisor = NewInt(10000000000000000000) // 19 zeroes
+		divisor = NewInt(10000000000000000000) // 20 digits
 		y       = new(Int).Set(z)              // copy to avoid modifying z
 		pos     = 78 + 20                      // position to write to
 		buf     = make([]byte, 0, 19)          // buffer to write uint64:s to

--- a/decimal.go
+++ b/decimal.go
@@ -6,6 +6,7 @@ package uint256
 
 import (
 	"io"
+	"math"
 	"strconv"
 )
 
@@ -16,17 +17,19 @@ func (z *Int) Dec() string {
 	if z.IsZero() {
 		return "0"
 	}
+	if z.LtUint64(math.MaxInt64) {
+		return strconv.FormatInt(int64(z.Uint64()), 10)
+	}
 	var (
-		ten   = NewInt(10)
-		y     = new(Int).Set(z)
-		chars = []byte("0123456789")
-		out   = make([]byte, 0, 78)
+		ten = NewInt(10)
+		y   = new(Int).Set(z)
+		out = make([]byte, 0, 78)
 	)
 	for !y.IsZero() {
 		var quot Int
 		rem := udivrem(quot[:], y[:], ten)
 		y.Set(&quot)
-		out = append(out, chars[rem.Uint64()%10])
+		out = append(out, byte(0x30+rem.Uint64()%10))
 	}
 	for i := 0; i < len(out)/2; i++ {
 		out[i], out[len(out)-1-i] = out[len(out)-1-i], out[i]
@@ -44,7 +47,6 @@ func (z *Int) PrettyDec(separator byte) string {
 	var (
 		ten   = NewInt(10)
 		y     = new(Int).Set(z)
-		chars = []byte("0123456789")
 		out   = make([]byte, 0, 103)
 		comma int
 	)
@@ -56,7 +58,7 @@ func (z *Int) PrettyDec(separator byte) string {
 		var quot Int
 		rem := udivrem(quot[:], y[:], ten)
 		y.Set(&quot)
-		out = append(out, chars[rem.Uint64()%10])
+		out = append(out, byte(30+rem.Uint64()%10))
 		comma++
 	}
 	for i := 0; i < len(out)/2; i++ {

--- a/decimal.go
+++ b/decimal.go
@@ -6,13 +6,40 @@ package uint256
 
 import (
 	"io"
+	"math"
 	"strconv"
 )
 
 const twoPow256Sub1 = "115792089237316195423570985008687907853269984665640564039457584007913129639935"
 
+// Dec returns the decimal representation of z.
+// OBS: This method is not optimized, and uses big.Int-conversion under the hood (TODO!)
 func (z *Int) Dec() string {
-	return z.ToBig().String()
+	if z.LtUint64(math.MaxInt64) {
+		return strconv.FormatInt(int64(z.Uint64()), 10)
+	}
+	return z.ToBig().Text(10)
+}
+
+// PrettyDec returns the decimal representation of z, with thousands-separators.
+// OBS: This method is not optimized, and uses big.Int-conversion under the hood (TODO!)
+func (z *Int) PrettyDec(separator byte) string {
+	var (
+		text  = z.Dec()
+		buf   = make([]byte, len(text)+len(text)/3)
+		comma = 0
+		i     = len(buf) - 1
+	)
+	for j := len(text) - 1; j >= 0; j, i = j-1, i-1 {
+		if comma == 3 {
+			buf[i] = separator
+			i--
+			comma = 0
+		}
+		buf[i] = text[j]
+		comma++
+	}
+	return string(buf[i+1:])
 }
 
 // FromDecimal is a convenience-constructor to create an Int from a

--- a/decimal.go
+++ b/decimal.go
@@ -17,7 +17,7 @@ func (z *Int) Dec() string {
 		return "0"
 	}
 	if z.IsUint64() {
-		return strconv.FormatUint(uint64(z.Uint64()), 10)
+		return strconv.FormatUint(z.Uint64(), 10)
 	}
 	// The max uint64 value is 18446744073709551615, thus the largest
 	// base10 power-of-ten number is 10000000000000000000.
@@ -52,7 +52,6 @@ func (z *Int) Dec() string {
 		pos -= 19
 		// Copy in the ascii digits
 		copy(out[pos+19-buflen:], buf[:])
-
 	}
 	// skip leading zeroes by only using the 'used size' of buf
 	return string(out[pos+19-buflen:])
@@ -63,29 +62,23 @@ func (z *Int) PrettyDec(separator byte) string {
 	if z.IsZero() {
 		return "0"
 	}
-	// Largest string has 103 characters:
-	// 115,792,089,237,316,195,423,570,985,008,687,907,853,269,984,665,640,564,039,457,584,007,913,129,639,935
 	var (
-		ten   = NewInt(10)
-		y     = new(Int).Set(z)
-		out   = make([]byte, 0, 103)
-		comma int
+		text  = z.Dec()
+		buf   = make([]byte, len(text)+len(text)/3)
+		comma = 0
+		i     = len(buf) - 1
 	)
-	for !y.IsZero() {
+	for j := len(text) - 1; j >= 0; j, i = j-1, i-1 {
+		c := text[j]
 		if comma == 3 {
-			out = append(out, separator)
+			buf[i] = ','
+			i--
 			comma = 0
 		}
-		var quot Int
-		rem := udivrem(quot[:], y[:], ten)
-		y.Set(&quot)
-		out = append(out, byte(30+rem.Uint64()%10))
+		buf[i] = c
 		comma++
 	}
-	for i := 0; i < len(out)/2; i++ {
-		out[i], out[len(out)-1-i] = out[len(out)-1-i], out[i]
-	}
-	return string(out)
+	return string(buf[i+1:])
 }
 
 // FromDecimal is a convenience-constructor to create an Int from a


### PR DESCRIPTION
This PR implements the `Dec` method 'natively', and adds the API-method `PrettyDec`.

```golang
// Dec returns the decimal representation of z.
func (z *Int) Dec() string

// PrettyDec returns the decimal representation of z, with thousands-separators.
func (z *Int) PrettyDec(separator byte) string 
```
It also adds benchmarks and a new fuzz-test for the changed methods. 
```
BenchmarkDecimal/ToDecimal/uint256-8         	   12324	    102673 ns/op	   11344 B/op	     248 allocs/op
BenchmarkDecimal/ToPrettyDecimal/uint256-8   	    9595	    110235 ns/op	   14720 B/op	     251 allocs/op
BenchmarkDecimal/ToDecimal/big-8             	   10000	    133930 ns/op	   31920 B/op	     594 allocs/op

```
