### PR TITLE
implement `MustFromHex` and `MustFromDecimal`

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -127,6 +127,17 @@ func FromHex(hex string) (*Int, error) {
 	return &z, nil
 }
 
+// MustFromHex is a convenience-constructor to create an Int from
+// a hexadecimal string.
+// Returns a new Int and panics if any error occurred.
+func MustFromHex(hex string) *Int {
+	var z Int
+	if err := z.fromHex(hex); err != nil {
+		panic(err)
+	}
+	return &z
+}
+
 // UnmarshalText implements encoding.TextUnmarshaler
 func (z *Int) UnmarshalText(input []byte) error {
 	z.Clear()

--- a/decimal.go
+++ b/decimal.go
@@ -120,6 +120,17 @@ func FromDecimal(decimal string) (*Int, error) {
 	return &z, nil
 }
 
+// MustFromDecimal is a convenience-constructor to create an Int from a
+// decimal (base 10) string.
+// Returns a new Int and panics if any error occurred.
+func MustFromDecimal(decimal string) *Int {
+	var z Int
+	if err := z.SetFromDecimal(decimal); err != nil {
+		panic(err)
+	}
+	return &z
+}
+
 // SetFromDecimal sets z from the given string, interpreted as a decimal number.
 // OBS! This method is _not_ strictly identical to the (*big.Int).SetString(..., 10) method.
 // Notable differences:

--- a/decimal_test.go
+++ b/decimal_test.go
@@ -5,6 +5,7 @@
 package uint256
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"testing"
@@ -18,6 +19,14 @@ func testSetFromDec(tc string) error {
 		b, err2 := FromDecimal(tc)
 		if (err == nil) != (err2 == nil) {
 			return fmt.Errorf("err != err2: %v %v", err, err2)
+		}
+		// Test the MustFromDecimal too
+		if err != nil {
+			if !causesPanic(func() { MustFromDecimal(tc) }) {
+				return errors.New("expected panic")
+			}
+		} else {
+			MustFromDecimal(tc) // must not manic
 		}
 		if err == nil {
 			if a.Cmp(b) != 0 {


### PR DESCRIPTION
The PR https://github.com/holiman/uint256/pull/128 added `MustFromBig`, this PR adds two similar helpers: `MustFromHex` and `MustFromDecimal`. 

```golang
// MustFromHex is a convenience-constructor to create an Int from
// a hexadecimal string.
// Returns a new Int and panics if any error occurred.
func MustFromHex(hex string) *Int 

// MustFromDecimal is a convenience-constructor to create an Int from a
// decimal (base 10) string.
// Returns a new Int and panics if any error occurred.
func MustFromDecimal(decimal string) *Int 
```