### PR TITLE
implement `Float64() float64`

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -92,17 +92,16 @@ func (z *Int) Float64() float64 {
 	//
 	// 1: https://www.wikihow.com/Convert-a-Number-from-Decimal-to-IEEE-754-Floating-Point-Representation
 
-	const bias = uint64(1023) // double-precision uses 1023 as bias
+	bitlen := uint64(z.BitLen())
 
 	// Normalize the number, by shifting it so that the MSB is shifted out.
-	shifts := uint(1 + 256 - z.BitLen())
-
+	y := new(Int).Lsh(z, uint(1+256-bitlen))
 	// The number with the leading 1 shifted out is the fraction.
-	y := new(Int).Lsh(z, shifts)
 	fraction := y[3]
 
 	// The exp is calculated from the number of shifts, adjusted with the bias.
-	biased_exp := bias + uint64(256-shifts)
+	// double-precision uses 1023 as bias
+	biased_exp := 1023 + bitlen - 1
 
 	// The IEEE 754 double-precision layout is as follows:
 	//  1 sign bit (we don't bother with this, since it's always zero for uints)

--- a/conversion.go
+++ b/conversion.go
@@ -76,6 +76,20 @@ func MustFromBig(b *big.Int) *Int {
 	return z
 }
 
+// Float64 returns the float64 value nearest to x. If x is too small to be
+// represented by a float64 (|x| < math.SmallestNonzeroFloat64), the result
+// is (0, Below) or (-0, Above), respectively, depending on the sign of x.
+// If x is too large to be represented by a float64 (|x| > math.MaxFloat64),
+// the result is (+Inf, Above) or (-Inf, Below), depending on the sign of x.
+//
+// OBS! Currently, this method is not optimized: but uses big.Int and big.Float.
+func (z *Int) Float64() (float64, big.Accuracy) {
+	if z.IsUint64() {
+		return new(big.Float).SetUint64(z.Uint64()).Float64()
+	}
+	return new(big.Float).SetInt(z.ToBig()).Float64()
+}
+
 // SetFromHex sets z from the given string, interpreted as a hexadecimal number.
 // OBS! This method is _not_ strictly identical to the (*big.Int).SetString(..., 16) method.
 // Notable differences:

--- a/conversion.go
+++ b/conversion.go
@@ -87,8 +87,7 @@ func MustFromBig(b *big.Int) *Int {
 // OBS! Currently, this method is not optimized: but uses big.Int and big.Float.
 func (z *Int) Float64() float64 {
 	if z.IsUint64() {
-		f, _ := new(big.Float).SetUint64(z.Uint64()).Float64()
-		return f
+		return float64(z.Uint64())
 	}
 	f, _ := new(big.Float).SetInt(z.ToBig()).Float64()
 	return f

--- a/conversion.go
+++ b/conversion.go
@@ -76,18 +76,22 @@ func MustFromBig(b *big.Int) *Int {
 	return z
 }
 
-// Float64 returns the float64 value nearest to x. If x is too small to be
-// represented by a float64 (|x| < math.SmallestNonzeroFloat64), the result
-// is (0, Below) or (-0, Above), respectively, depending on the sign of x.
-// If x is too large to be represented by a float64 (|x| > math.MaxFloat64),
-// the result is (+Inf, Above) or (-Inf, Below), depending on the sign of x.
+// Float64 returns the float64 value nearest to x.
+//
+// Note: The `big.Float` version of `Float64` also returns an 'Accuracy', indicating
+// whether the value was too small or too large to be represented by a
+// `float64`. However, the `uint256` type is unable to represent values
+// out of scope (|x| < math.SmallestNonzeroFloat64 or |x| > math.MaxFloat64),
+// therefore this method does not return any accuracy.
 //
 // OBS! Currently, this method is not optimized: but uses big.Int and big.Float.
-func (z *Int) Float64() (float64, big.Accuracy) {
+func (z *Int) Float64() float64 {
 	if z.IsUint64() {
-		return new(big.Float).SetUint64(z.Uint64()).Float64()
+		f, _ := new(big.Float).SetUint64(z.Uint64()).Float64()
+		return f
 	}
-	return new(big.Float).SetInt(z.ToBig()).Float64()
+	f, _ := new(big.Float).SetInt(z.ToBig()).Float64()
+	return f
 }
 
 // SetFromHex sets z from the given string, interpreted as a hexadecimal number.

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1481,14 +1481,10 @@ func TestFloat64(t *testing.T) {
 	for i := uint(0); i < 255; i++ {
 		z := NewInt(1)
 		z.Lsh(z, i)
-		bigF, bigAcc := new(big.Float).SetInt(z.ToBig()).Float64()
-		_, _ = z.Float64() // Op must not modify the z
-		u256F, u256Acc := z.Float64()
-		if have, want := u256F, bigF; have != want {
+		bigF, _ := new(big.Float).SetInt(z.ToBig()).Float64()
+		_ = z.Float64() // Op must not modify the z
+		if have, want := z.Float64(), bigF; have != want {
 			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
-		}
-		if have, want := u256Acc, bigAcc; have != want {
-			t.Errorf("%s: have %v want %v", z.Hex(), have, want)
 		}
 	}
 }
@@ -1496,14 +1492,10 @@ func TestFloat64(t *testing.T) {
 func FuzzFloat64(f *testing.F) {
 	f.Fuzz(func(t *testing.T, aa, bb, cc, dd uint64) {
 		z := &Int{aa, bb, cc, dd}
-		bigF, bigAcc := new(big.Float).SetInt(z.ToBig()).Float64()
-		_, _ = z.Float64() // Op must not modify the z
-		u256F, u256Acc := z.Float64()
-		if have, want := u256F, bigF; have != want {
+		bigF, _ := new(big.Float).SetInt(z.ToBig()).Float64()
+		_ = z.Float64() // Op must not modify the z
+		if have, want := z.Float64(), bigF; have != want {
 			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
-		}
-		if have, want := u256Acc, bigAcc; have != want {
-			t.Errorf("%s: have %v want %v", z.Hex(), have, want)
 		}
 	})
 }
@@ -1522,7 +1514,7 @@ func BenchmarkFloat64(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			for _, z := range u256Ints {
-				_, _ = z.Float64()
+				_ = z.Float64()
 			}
 		}
 	})

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1476,3 +1476,62 @@ func BenchmarkDecimal(b *testing.B) {
 		}
 	})
 }
+
+func TestFloat64(t *testing.T) {
+	for i := uint(0); i < 255; i++ {
+		z := NewInt(1)
+		z.Lsh(z, i)
+		bigF, bigAcc := new(big.Float).SetInt(z.ToBig()).Float64()
+		_, _ = z.Float64() // Op must not modify the z
+		u256F, u256Acc := z.Float64()
+		if have, want := u256F, bigF; have != want {
+			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
+		}
+		if have, want := u256Acc, bigAcc; have != want {
+			t.Errorf("%s: have %v want %v", z.Hex(), have, want)
+		}
+	}
+}
+
+func FuzzFloat64(f *testing.F) {
+	f.Fuzz(func(t *testing.T, aa, bb, cc, dd uint64) {
+		z := &Int{aa, bb, cc, dd}
+		bigF, bigAcc := new(big.Float).SetInt(z.ToBig()).Float64()
+		_, _ = z.Float64() // Op must not modify the z
+		u256F, u256Acc := z.Float64()
+		if have, want := u256F, bigF; have != want {
+			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
+		}
+		if have, want := u256Acc, bigAcc; have != want {
+			t.Errorf("%s: have %v want %v", z.Hex(), have, want)
+		}
+	})
+}
+
+func BenchmarkFloat64(b *testing.B) {
+	var u256Ints []*Int
+	var bigints []*big.Int
+
+	for i := uint(0); i < 255; i++ {
+		a := NewInt(1)
+		a.Lsh(a, i)
+		u256Ints = append(u256Ints, a)
+		bigints = append(bigints, a.ToBig())
+	}
+	b.Run("Float64/uint256", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for _, z := range u256Ints {
+				_, _ = z.Float64()
+			}
+		}
+	})
+	b.Run("Float64/big", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			for _, z := range bigints {
+				_, _ = new(big.Float).SetInt(z).Float64()
+			}
+		}
+	})
+}

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1477,26 +1477,24 @@ func BenchmarkDecimal(b *testing.B) {
 	})
 }
 
+func testFloat64(t *testing.T, z *Int) {
+	bigF, _ := new(big.Float).SetInt(z.ToBig()).Float64()
+	_ = z.Float64() // Op must not modify the z
+	if have, want := z.Float64(), bigF; have != want {
+		t.Errorf("%s: have %f want %f", z.Hex(), have, want)
+	}
+}
+
 func TestFloat64(t *testing.T) {
 	for i := uint(0); i < 255; i++ {
 		z := NewInt(1)
-		z.Lsh(z, i)
-		bigF, _ := new(big.Float).SetInt(z.ToBig()).Float64()
-		_ = z.Float64() // Op must not modify the z
-		if have, want := z.Float64(), bigF; have != want {
-			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
-		}
+		testFloat64(t, z.Lsh(z, i))
 	}
 }
 
 func FuzzFloat64(f *testing.F) {
 	f.Fuzz(func(t *testing.T, aa, bb, cc, dd uint64) {
-		z := &Int{aa, bb, cc, dd}
-		bigF, _ := new(big.Float).SetInt(z.ToBig()).Float64()
-		_ = z.Float64() // Op must not modify the z
-		if have, want := z.Float64(), bigF; have != want {
-			t.Errorf("%s: have %f want %f", z.Hex(), have, want)
-		}
+		testFloat64(t, &Int{aa, bb, cc, dd})
 	})
 }
 


### PR DESCRIPTION
Ref: https://github.com/holiman/uint256/issues/123 

This PR implements 
```
// Float64 returns the float64 value nearest to x.
//
// Note: The `big.Float` version of `Float64` also returns an 'Accuracy', indicating
// whether the value was too small or too large to be represented by a
// `float64`. However, the `uint256` type is unable to represent values
// out of scope (|x| < math.SmallestNonzeroFloat64 or |x| > math.MaxFloat64),
// therefore this method does not return any accuracy.
//
// OBS! Currently, this method is not optimized: but uses big.Int and big.Float.
func (z *Int) Float64() float64
```
Implementing `Float64` makes it possible to use e.g. the logarithm functions in the `math` package. 

Todo: 

- [x] Implement native to-float support without using package `big`