### PR TITLE
Allow converting between nil big.Int and nil uint256.Int

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -42,6 +42,9 @@ var (
 
 // ToBig returns a big.Int version of z.
 func (z *Int) ToBig() *big.Int {
+	if z == nil {
+		return nil
+	}
 	b := new(big.Int)
 	switch maxWords { // Compile-time check.
 	case 4: // 64-bit architectures.
@@ -62,6 +65,9 @@ func (z *Int) ToBig() *big.Int {
 // FromBig is a convenience-constructor from big.Int.
 // Returns a new Int and whether overflow occurred.
 func FromBig(b *big.Int) (*Int, bool) {
+	if b == nil {
+		return nil, false
+	}
 	z := &Int{}
 	overflow := z.SetFromBig(b)
 	return z, overflow
@@ -70,6 +76,9 @@ func FromBig(b *big.Int) (*Int, bool) {
 // MustFromBig is a convenience-constructor from big.Int.
 // Returns a new Int and panics if overflow occurred.
 func MustFromBig(b *big.Int) *Int {
+	if b == nil {
+		return nil
+	}
 	z := &Int{}
 	if z.SetFromBig(b) {
 		panic("overflow")

--- a/conversion.go
+++ b/conversion.go
@@ -76,6 +76,8 @@ func FromBig(b *big.Int) (*Int, bool) {
 
 // MustFromBig is a convenience-constructor from big.Int.
 // Returns a new Int and panics if overflow occurred.
+// OBS: If b is `nil`, this method does _not_ panic, but 
+// instead returns `nil`
 func MustFromBig(b *big.Int) *Int {
 	if b == nil {
 		return nil

--- a/conversion.go
+++ b/conversion.go
@@ -64,6 +64,7 @@ func (z *Int) ToBig() *big.Int {
 
 // FromBig is a convenience-constructor from big.Int.
 // Returns a new Int and whether overflow occurred.
+// OBS: If b is `nil`, this method returns `nil, false`
 func FromBig(b *big.Int) (*Int, bool) {
 	if b == nil {
 		return nil, false

--- a/conversion.go
+++ b/conversion.go
@@ -41,6 +41,7 @@ var (
 )
 
 // ToBig returns a big.Int version of z.
+// Return `nil` if z is nil
 func (z *Int) ToBig() *big.Int {
 	if z == nil {
 		return nil

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -225,7 +225,7 @@ func TestFromBigOverflow(t *testing.T) {
 func TestToBig(t *testing.T) {
 	var uint256Nil *Int
 	if bigNil := uint256Nil.ToBig(); bigNil != nil {
-		t.Errorf("expected big.Int <nil>, got %x", bigNil)
+		t.Errorf("want big.Int <nil>, have %x", bigNil)
 	}
 	if bigZero := new(Int).ToBig(); bigZero.Cmp(new(big.Int)) != 0 {
 		t.Errorf("expected big.Int 0, got %x", bigZero)

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -19,15 +19,27 @@ var (
 )
 
 func TestFromBig(t *testing.T) {
-	a := new(big.Int)
+	var a *big.Int
 	b, o := FromBig(a)
+	if o {
+		t.Fatalf("nil conversion overflowed! big.Int %x", b)
+	}
+	if b != nil {
+		t.Fatalf("got %x, exp %v", b, nil)
+	}
+	b2 := MustFromBig(a)
+	if b2 != nil {
+		t.Fatalf("got %x, exp %v", b2, nil)
+	}
+	a = new(big.Int)
+	b, o = FromBig(a)
 	if o {
 		t.Fatalf("conversion overflowed! big.Int %x", a.Bytes())
 	}
 	if exp, got := a.Bytes(), b.Bytes(); !bytes.Equal(got, exp) {
 		t.Fatalf("got %x exp %x", got, exp)
 	}
-	b2 := MustFromBig(a)
+	b2 = MustFromBig(a)
 	if exp, got := a.Bytes(), b2.Bytes(); !bytes.Equal(got, exp) {
 		t.Fatalf("got %x exp %x", got, exp)
 	}
@@ -211,7 +223,10 @@ func TestFromBigOverflow(t *testing.T) {
 }
 
 func TestToBig(t *testing.T) {
-
+	var uint256Nil *Int
+	if bigNil := uint256Nil.ToBig(); bigNil != nil {
+		t.Errorf("expected big.Int <nil>, got %x", bigNil)
+	}
 	if bigZero := new(Int).ToBig(); bigZero.Cmp(new(big.Int)) != 0 {
 		t.Errorf("expected big.Int 0, got %x", bigZero)
 	}


### PR DESCRIPTION
This is perhaps a debatable change, but may be more logical than originally anticipated.

In some places, having a `nil` as a `big.Int` or `uint256.Int` might make sense (e.g. an optional and non-initialized field). In those cases, converting between the two across older/newer code might be necessary. In it's current incarnation, the uint256 library will crash, so all optional nils need to be special cased.

IMHO this should not be necessary. If a uint256 should not be nil, but a nil big int is passed, then I assume the code later will crash anyway on some uint256 accessor method whether we crash at the conversion or not, so it's not like we're silently swallowing up errors. On the other hand, allowing the nils to be converted back and forth reduces the error potential of forgetting to special case an optional nil somewhere and blowing up runtime.