### PR TITLE
Implement `CmpBig`

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -375,9 +375,32 @@ func benchmark_Cmp_Bit(bench *testing.B) {
 		f2.Cmp(f)
 	}
 }
+
 func BenchmarkCmp(bench *testing.B) {
 	bench.Run("single/big", benchmark_Cmp_Big)
 	bench.Run("single/uint256", benchmark_Cmp_Bit)
+}
+
+func BenchmarkCmpBig(bench *testing.B) {
+	// This bench tests where the Cmp is non-equal
+	bench.Run("nonequal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			x := &big256Samples[i%len(big256Samples)]
+			z := &int256Samples[len(int256Samples)-(i%len(int256Samples))-1]
+			_ = z.CmpBig(x)
+		}
+	})
+	bench.Run("equal", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			x := &big256Samples[i%len(big256Samples)]
+			z := &int256Samples[i%len(big256Samples)]
+			if z.CmpBig(x) != 0 {
+				b.Fatal("test error")
+			}
+		}
+	})
 }
 
 func BenchmarkLt(b *testing.B) {

--- a/uint256.go
+++ b/uint256.go
@@ -9,6 +9,7 @@ package uint256
 import (
 	"encoding/binary"
 	"math"
+	"math/big"
 	"math/bits"
 )
 
@@ -930,6 +931,24 @@ func (z *Int) Cmp(x *Int) (r int) {
 		return 0
 	}
 	return 1
+}
+
+// CmpBig compares z and x and returns:
+//
+//	-1 if z <  x
+//	 0 if z == x
+//	+1 if z >  x
+func (z *Int) CmpBig(x *big.Int) (r int) {
+	// If x is negative, it's surely smaller (z > x)
+	if x.Sign() == -1 {
+		return 1
+	}
+	y := new(Int)
+	if y.SetFromBig(x) { // overflow
+		// z < x
+		return -1
+	}
+	return z.Cmp(y)
 }
 
 // LtUint64 returns true if z is smaller than n

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -788,11 +788,13 @@ func TestRandomSDiv(t *testing.T) {
 
 func TestUdivremQuick(t *testing.T) {
 	//
-	u := []uint64{1, 0, 0, 0, 0}
-	d := Int{0, 1, 0, 0}
-	quot := []uint64{}
+	var (
+		u        = []uint64{1, 0, 0, 0, 0}
+		d        = Int{0, 1, 0, 0}
+		quot     []uint64
+		expected = new(Int)
+	)
 	rem := udivrem(quot, u, &d)
-	expected := new(Int)
 	copy(expected[:], u)
 	if !rem.Eq(expected) {
 		t.Errorf("Wrong remainder: %x, expected %x", rem, expected)

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -1667,5 +1667,9 @@ func TestCmpBig(t *testing.T) {
 		testCmpBig(t, z, new(Int).AddUint64(z, 1).ToBig())
 		// z, z - 1
 		testCmpBig(t, z, new(Int).SubUint64(z, 1).ToBig())
+		// z, -z
+		testCmpBig(t, z, new(big.Int).Neg(new(Int).Set(z).ToBig()))
+		// z, z << 256
+		testCmpBig(t, z, new(big.Int).Lsh(new(Int).Set(z).ToBig(), 256))
 	}
 }

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -1648,3 +1648,24 @@ func TestByte32Representation(t *testing.T) {
 		}
 	}
 }
+
+func testCmpBig(t *testing.T, z *Int, x *big.Int) {
+	want := z.ToBig().Cmp(x)
+	have := z.CmpBig(x)
+	if have != want {
+		t.Errorf("%s.CmpBig( %x ) : have %v want %v", z.Hex(), x, have, want)
+	}
+}
+
+func TestCmpBig(t *testing.T) {
+	for i := uint(0); i < 255; i++ {
+		z := NewInt(1)
+		z.Lsh(z, i)
+		// z, z
+		testCmpBig(t, z, new(Int).Set(z).ToBig())
+		// z, z + 1
+		testCmpBig(t, z, new(Int).AddUint64(z, 1).ToBig())
+		// z, z - 1
+		testCmpBig(t, z, new(Int).SubUint64(z, 1).ToBig())
+	}
+}


### PR DESCRIPTION
This PR implements
```
// CmpBig compares z and x and returns:
//
//	-1 if z <  x
//	 0 if z == x
//	+1 if z >  x
func (z *Int) CmpBig(x *big.Int) (r int) 
```
After some benchmarking, it turned out that converting from big to `Int` was not significantly slower than e.g pre-checking the `BitLength`, so I went with that in the end.  

Closes https://github.com/holiman/uint256/issues/135
