### PR TITLE
conversion: revert json-marshalling change in #144, marshal hex-format

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -623,14 +623,14 @@ func (z *Int) MarshalText() ([]byte, error) {
 }
 
 // MarshalJSON implements json.Marshaler.
-// MarshalJSON marshals using the 'decimal string' representation. This is _not_ compatible
+// MarshalJSON marshals using 'hex' representation. This is _not_ compatible
 // with big.Int: big.Int marshals into JSON 'native' numeric format.
 //
 // The JSON  native format is, on some platforms, (e.g. javascript), limited to 53-bit large
 // integer space. Thus, U256 uses string-format, which is not compatible with
 // big.int (big.Int refuses to unmarshal a string representation).
 func (z *Int) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + z.Dec() + `"`), nil
+	return []byte(`"` + z.Hex() + `"`), nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler. UnmarshalJSON accepts either

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -1241,7 +1241,7 @@ func TestEnDecode(t *testing.T) {
 		}
 		{
 			have, _ := intSample.MarshalJSON()
-			want := []byte(fmt.Sprintf(`"%s"`, bigSample.Text(10)))
+			want := []byte(fmt.Sprintf(`"0x%s"`, bigSample.Text(16)))
 			if !bytes.Equal(have, want) {
 				t.Fatalf("test %d MarshalJSON, have %q, want %q", i, have, want)
 			}


### PR DESCRIPTION
This undoes the change in json-marshalling, making it so that we (again) marshal `uint256.Int` in hex-format. This is more widely useful in go-ethereum. 

I originally intended to let it be this way, but I changed my mind due to this comment: https://github.com/holiman/uint256/pull/144#discussion_r1405828059. 

This would be an alternative to https://github.com/ethereum/go-ethereum/pull/28628

cc @fjl @karalabe 