### PR TITLE
Chore: Reordered the `SetBytesXXX` function and fixed comments

### DIFF
--- a/conversion.go
+++ b/conversion.go
@@ -254,11 +254,129 @@ func (z *Int) Format(s fmt.State, ch rune) {
 	z.ToBig().Format(s, ch)
 }
 
+// SetBytes1 is identical to SetBytes(in[:1]), but panics is input is too short
+func (z *Int) SetBytes1(in []byte) *Int {
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = uint64(in[0])
+	return z
+}
+
+// SetBytes2 is identical to SetBytes(in[:2]), but panics is input is too short
+func (z *Int) SetBytes2(in []byte) *Int {
+	_ = in[1] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = uint64(binary.BigEndian.Uint16(in[0:2]))
+	return z
+}
+
+// SetBytes3 is identical to SetBytes(in[:3]), but panics is input is too short
+func (z *Int) SetBytes3(in []byte) *Int {
+	_ = in[2] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
+	return z
+}
+
+// SetBytes4 is identical to SetBytes(in[:4]), but panics is input is too short
+func (z *Int) SetBytes4(in []byte) *Int {
+	_ = in[3] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = uint64(binary.BigEndian.Uint32(in[0:4]))
+	return z
+}
+
+// SetBytes5 is identical to SetBytes(in[:5]), but panics is input is too short
+func (z *Int) SetBytes5(in []byte) *Int {
+	_ = in[4] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = bigEndianUint40(in[0:5])
+	return z
+}
+
+// SetBytes6 is identical to SetBytes(in[:6]), but panics is input is too short
+func (z *Int) SetBytes6(in []byte) *Int {
+	_ = in[5] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = bigEndianUint48(in[0:6])
+	return z
+}
+
+// SetBytes7 is identical to SetBytes(in[:7]), but panics is input is too short
+func (z *Int) SetBytes7(in []byte) *Int {
+	_ = in[6] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2], z[1] = 0, 0, 0
+	z[0] = bigEndianUint56(in[0:7])
+	return z
+}
+
 // SetBytes8 is identical to SetBytes(in[:8]), but panics is input is too short
 func (z *Int) SetBytes8(in []byte) *Int {
 	_ = in[7] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3], z[2], z[1] = 0, 0, 0
 	z[0] = binary.BigEndian.Uint64(in[0:8])
+	return z
+}
+
+// SetBytes9 is identical to SetBytes(in[:9]), but panics is input is too short
+func (z *Int) SetBytes9(in []byte) *Int {
+	_ = in[8] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = uint64(in[0])
+	z[0] = binary.BigEndian.Uint64(in[1:9])
+	return z
+}
+
+// SetBytes10 is identical to SetBytes(in[:10]), but panics is input is too short
+func (z *Int) SetBytes10(in []byte) *Int {
+	_ = in[9] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = uint64(binary.BigEndian.Uint16(in[0:2]))
+	z[0] = binary.BigEndian.Uint64(in[2:10])
+	return z
+}
+
+// SetBytes11 is identical to SetBytes(in[:11]), but panics is input is too short
+func (z *Int) SetBytes11(in []byte) *Int {
+	_ = in[10] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
+	z[0] = binary.BigEndian.Uint64(in[3:11])
+	return z
+}
+
+// SetBytes12 is identical to SetBytes(in[:12]), but panics is input is too short
+func (z *Int) SetBytes12(in []byte) *Int {
+	_ = in[11] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = uint64(binary.BigEndian.Uint32(in[0:4]))
+	z[0] = binary.BigEndian.Uint64(in[4:12])
+	return z
+}
+
+// SetBytes13 is identical to SetBytes(in[:13]), but panics is input is too short
+func (z *Int) SetBytes13(in []byte) *Int {
+	_ = in[12] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = bigEndianUint40(in[0:5])
+	z[0] = binary.BigEndian.Uint64(in[5:13])
+	return z
+}
+
+// SetBytes14 is identical to SetBytes(in[:14]), but panics is input is too short
+func (z *Int) SetBytes14(in []byte) *Int {
+	_ = in[13] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = bigEndianUint48(in[0:6])
+	z[0] = binary.BigEndian.Uint64(in[6:14])
+	return z
+}
+
+// SetBytes15 is identical to SetBytes(in[:15]), but panics is input is too short
+func (z *Int) SetBytes15(in []byte) *Int {
+	_ = in[14] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3], z[2] = 0, 0
+	z[1] = bigEndianUint56(in[0:7])
+	z[0] = binary.BigEndian.Uint64(in[7:15])
 	return z
 }
 
@@ -271,39 +389,7 @@ func (z *Int) SetBytes16(in []byte) *Int {
 	return z
 }
 
-// SetBytes16 is identical to SetBytes(in[:24]), but panics is input is too short
-func (z *Int) SetBytes24(in []byte) *Int {
-	_ = in[23] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = 0
-	z[2] = binary.BigEndian.Uint64(in[0:8])
-	z[1] = binary.BigEndian.Uint64(in[8:16])
-	z[0] = binary.BigEndian.Uint64(in[16:24])
-	return z
-}
-
-func (z *Int) SetBytes32(in []byte) *Int {
-	_ = in[31] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = binary.BigEndian.Uint64(in[0:8])
-	z[2] = binary.BigEndian.Uint64(in[8:16])
-	z[1] = binary.BigEndian.Uint64(in[16:24])
-	z[0] = binary.BigEndian.Uint64(in[24:32])
-	return z
-}
-
-func (z *Int) SetBytes1(in []byte) *Int {
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = uint64(in[0])
-	return z
-}
-
-func (z *Int) SetBytes9(in []byte) *Int {
-	_ = in[8] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = uint64(in[0])
-	z[0] = binary.BigEndian.Uint64(in[1:9])
-	return z
-}
-
+// SetBytes17 is identical to SetBytes(in[:17]), but panics is input is too short
 func (z *Int) SetBytes17(in []byte) *Int {
 	_ = in[16] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -313,30 +399,7 @@ func (z *Int) SetBytes17(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes25(in []byte) *Int {
-	_ = in[24] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = uint64(in[0])
-	z[2] = binary.BigEndian.Uint64(in[1:9])
-	z[1] = binary.BigEndian.Uint64(in[9:17])
-	z[0] = binary.BigEndian.Uint64(in[17:25])
-	return z
-}
-
-func (z *Int) SetBytes2(in []byte) *Int {
-	_ = in[1] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = uint64(binary.BigEndian.Uint16(in[0:2]))
-	return z
-}
-
-func (z *Int) SetBytes10(in []byte) *Int {
-	_ = in[9] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = uint64(binary.BigEndian.Uint16(in[0:2]))
-	z[0] = binary.BigEndian.Uint64(in[2:10])
-	return z
-}
-
+// SetBytes18 is identical to SetBytes(in[:18]), but panics is input is too short
 func (z *Int) SetBytes18(in []byte) *Int {
 	_ = in[17] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -346,30 +409,7 @@ func (z *Int) SetBytes18(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes26(in []byte) *Int {
-	_ = in[25] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = uint64(binary.BigEndian.Uint16(in[0:2]))
-	z[2] = binary.BigEndian.Uint64(in[2:10])
-	z[1] = binary.BigEndian.Uint64(in[10:18])
-	z[0] = binary.BigEndian.Uint64(in[18:26])
-	return z
-}
-
-func (z *Int) SetBytes3(in []byte) *Int {
-	_ = in[2] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
-	return z
-}
-
-func (z *Int) SetBytes11(in []byte) *Int {
-	_ = in[10] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
-	z[0] = binary.BigEndian.Uint64(in[3:11])
-	return z
-}
-
+// SetBytes19 is identical to SetBytes(in[:19]), but panics is input is too short
 func (z *Int) SetBytes19(in []byte) *Int {
 	_ = in[18] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -379,30 +419,7 @@ func (z *Int) SetBytes19(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes27(in []byte) *Int {
-	_ = in[26] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
-	z[2] = binary.BigEndian.Uint64(in[3:11])
-	z[1] = binary.BigEndian.Uint64(in[11:19])
-	z[0] = binary.BigEndian.Uint64(in[19:27])
-	return z
-}
-
-func (z *Int) SetBytes4(in []byte) *Int {
-	_ = in[3] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = uint64(binary.BigEndian.Uint32(in[0:4]))
-	return z
-}
-
-func (z *Int) SetBytes12(in []byte) *Int {
-	_ = in[11] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = uint64(binary.BigEndian.Uint32(in[0:4]))
-	z[0] = binary.BigEndian.Uint64(in[4:12])
-	return z
-}
-
+// SetBytes20 is identical to SetBytes(in[:20]), but panics is input is too short
 func (z *Int) SetBytes20(in []byte) *Int {
 	_ = in[19] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -412,30 +429,7 @@ func (z *Int) SetBytes20(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes28(in []byte) *Int {
-	_ = in[27] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = uint64(binary.BigEndian.Uint32(in[0:4]))
-	z[2] = binary.BigEndian.Uint64(in[4:12])
-	z[1] = binary.BigEndian.Uint64(in[12:20])
-	z[0] = binary.BigEndian.Uint64(in[20:28])
-	return z
-}
-
-func (z *Int) SetBytes5(in []byte) *Int {
-	_ = in[4] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = bigEndianUint40(in[0:5])
-	return z
-}
-
-func (z *Int) SetBytes13(in []byte) *Int {
-	_ = in[12] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = bigEndianUint40(in[0:5])
-	z[0] = binary.BigEndian.Uint64(in[5:13])
-	return z
-}
-
+// SetBytes21 is identical to SetBytes(in[:21]), but panics is input is too short
 func (z *Int) SetBytes21(in []byte) *Int {
 	_ = in[20] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -445,30 +439,7 @@ func (z *Int) SetBytes21(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes29(in []byte) *Int {
-	_ = in[23] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = bigEndianUint40(in[0:5])
-	z[2] = binary.BigEndian.Uint64(in[5:13])
-	z[1] = binary.BigEndian.Uint64(in[13:21])
-	z[0] = binary.BigEndian.Uint64(in[21:29])
-	return z
-}
-
-func (z *Int) SetBytes6(in []byte) *Int {
-	_ = in[5] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = bigEndianUint48(in[0:6])
-	return z
-}
-
-func (z *Int) SetBytes14(in []byte) *Int {
-	_ = in[13] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = bigEndianUint48(in[0:6])
-	z[0] = binary.BigEndian.Uint64(in[6:14])
-	return z
-}
-
+// SetBytes22 is identical to SetBytes(in[:22]), but panics is input is too short
 func (z *Int) SetBytes22(in []byte) *Int {
 	_ = in[21] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -478,30 +449,7 @@ func (z *Int) SetBytes22(in []byte) *Int {
 	return z
 }
 
-func (z *Int) SetBytes30(in []byte) *Int {
-	_ = in[29] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3] = bigEndianUint48(in[0:6])
-	z[2] = binary.BigEndian.Uint64(in[6:14])
-	z[1] = binary.BigEndian.Uint64(in[14:22])
-	z[0] = binary.BigEndian.Uint64(in[22:30])
-	return z
-}
-
-func (z *Int) SetBytes7(in []byte) *Int {
-	_ = in[6] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2], z[1] = 0, 0, 0
-	z[0] = bigEndianUint56(in[0:7])
-	return z
-}
-
-func (z *Int) SetBytes15(in []byte) *Int {
-	_ = in[14] // bounds check hint to compiler; see golang.org/issue/14808
-	z[3], z[2] = 0, 0
-	z[1] = bigEndianUint56(in[0:7])
-	z[0] = binary.BigEndian.Uint64(in[7:15])
-	return z
-}
-
+// SetBytes23 is identical to SetBytes(in[:23]), but panics is input is too short
 func (z *Int) SetBytes23(in []byte) *Int {
 	_ = in[22] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = 0
@@ -511,12 +459,93 @@ func (z *Int) SetBytes23(in []byte) *Int {
 	return z
 }
 
+// SetBytes24 is identical to SetBytes(in[:24]), but panics is input is too short
+func (z *Int) SetBytes24(in []byte) *Int {
+	_ = in[23] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = 0
+	z[2] = binary.BigEndian.Uint64(in[0:8])
+	z[1] = binary.BigEndian.Uint64(in[8:16])
+	z[0] = binary.BigEndian.Uint64(in[16:24])
+	return z
+}
+
+// SetBytes25 is identical to SetBytes(in[:25]), but panics is input is too short
+func (z *Int) SetBytes25(in []byte) *Int {
+	_ = in[24] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = uint64(in[0])
+	z[2] = binary.BigEndian.Uint64(in[1:9])
+	z[1] = binary.BigEndian.Uint64(in[9:17])
+	z[0] = binary.BigEndian.Uint64(in[17:25])
+	return z
+}
+
+// SetBytes26 is identical to SetBytes(in[:26]), but panics is input is too short
+func (z *Int) SetBytes26(in []byte) *Int {
+	_ = in[25] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = uint64(binary.BigEndian.Uint16(in[0:2]))
+	z[2] = binary.BigEndian.Uint64(in[2:10])
+	z[1] = binary.BigEndian.Uint64(in[10:18])
+	z[0] = binary.BigEndian.Uint64(in[18:26])
+	return z
+}
+
+// SetBytes27 is identical to SetBytes(in[:27]), but panics is input is too short
+func (z *Int) SetBytes27(in []byte) *Int {
+	_ = in[26] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = uint64(binary.BigEndian.Uint16(in[1:3])) | uint64(in[0])<<16
+	z[2] = binary.BigEndian.Uint64(in[3:11])
+	z[1] = binary.BigEndian.Uint64(in[11:19])
+	z[0] = binary.BigEndian.Uint64(in[19:27])
+	return z
+}
+
+// SetBytes28 is identical to SetBytes(in[:28]), but panics is input is too short
+func (z *Int) SetBytes28(in []byte) *Int {
+	_ = in[27] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = uint64(binary.BigEndian.Uint32(in[0:4]))
+	z[2] = binary.BigEndian.Uint64(in[4:12])
+	z[1] = binary.BigEndian.Uint64(in[12:20])
+	z[0] = binary.BigEndian.Uint64(in[20:28])
+	return z
+}
+
+// SetBytes29 is identical to SetBytes(in[:29]), but panics is input is too short
+func (z *Int) SetBytes29(in []byte) *Int {
+	_ = in[23] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = bigEndianUint40(in[0:5])
+	z[2] = binary.BigEndian.Uint64(in[5:13])
+	z[1] = binary.BigEndian.Uint64(in[13:21])
+	z[0] = binary.BigEndian.Uint64(in[21:29])
+	return z
+}
+
+// SetBytes30 is identical to SetBytes(in[:30]), but panics is input is too short
+func (z *Int) SetBytes30(in []byte) *Int {
+	_ = in[29] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = bigEndianUint48(in[0:6])
+	z[2] = binary.BigEndian.Uint64(in[6:14])
+	z[1] = binary.BigEndian.Uint64(in[14:22])
+	z[0] = binary.BigEndian.Uint64(in[22:30])
+	return z
+}
+
+// SetBytes31 is identical to SetBytes(in[:31]), but panics is input is too short
 func (z *Int) SetBytes31(in []byte) *Int {
 	_ = in[30] // bounds check hint to compiler; see golang.org/issue/14808
 	z[3] = bigEndianUint56(in[0:7])
 	z[2] = binary.BigEndian.Uint64(in[7:15])
 	z[1] = binary.BigEndian.Uint64(in[15:23])
 	z[0] = binary.BigEndian.Uint64(in[23:31])
+	return z
+}
+
+// SetBytes32 is identical to SetBytes(in[:32]), but panics is input is too short
+func (z *Int) SetBytes32(in []byte) *Int {
+	_ = in[31] // bounds check hint to compiler; see golang.org/issue/14808
+	z[3] = binary.BigEndian.Uint64(in[0:8])
+	z[2] = binary.BigEndian.Uint64(in[8:16])
+	z[1] = binary.BigEndian.Uint64(in[16:24])
+	z[0] = binary.BigEndian.Uint64(in[24:32])
 	return z
 }
 


### PR DESCRIPTION
## Description

I sorted the `SetBytesN` functions in ascending order of `N`, and corrected parts where the name in the comment was wrong. For example, the `SetBytes24` function had `SetBytes16` in its comment. Additionally, since only some functions had comments, I added comments to the rest based on those previous comments.