### PR TITLE
uint256: optimize and add benchmark for Set

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -917,3 +917,28 @@ func BenchmarkHashTreeRoot(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkSet(bench *testing.B) {
+
+	benchmarkUint256 := func(bench *testing.B) {
+		a := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Set(a)
+		}
+	}
+	benchmarkBig := func(bench *testing.B) {
+		a := new(big.Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
+
+		result := new(big.Int)
+		bench.ResetTimer()
+		for i := 0; i < bench.N; i++ {
+			result.Set(a)
+		}
+	}
+
+	bench.Run("single/uint256", benchmarkUint256)
+	bench.Run("single/big", benchmarkBig)
+}

--- a/uint256.go
+++ b/uint256.go
@@ -1184,7 +1184,7 @@ sh192:
 
 // Set sets z to x and returns z.
 func (z *Int) Set(x *Int) *Int {
-	*z = *x
+	z[0], z[1], z[2], z[3] = x[0], x[1], x[2], x[3]
 	return z
 }
 


### PR DESCRIPTION
Not sure why shallow copy is slow in golang, but changing shallow copy to direct value copy boosts `Set` from 2 ns to 0.22 ns.

Running
```
go test ./...
```
returns
```
ok  	github.com/holiman/uint256	0.975s
```

## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                      │     old      │                 new                  │
                      │    sec/op    │    sec/op     vs base                │
Set/single/uint256-16   2.0205n ± 1%   0.2160n ± 2%  -89.31% (p=0.000 n=10)
Set/single/big-16        2.908n ± 1%    2.925n ± 2%        ~ (p=0.516 n=10)
geomean                  2.424n        0.7950n       -67.20%

                      │     old      │                 new                 │
                      │     B/op     │    B/op     vs base                 │
Set/single/uint256-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Set/single/big-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │     old      │                 new                 │
                      │  allocs/op   │ allocs/op   vs base                 │
Set/single/uint256-16   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Set/single/big-16       0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```