### PR TITLE
benchmarking: fix BenchmarkMulDivOverflow

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -870,7 +870,8 @@ func BenchmarkMulDivOverflow(b *testing.B) {
 			x := factorsSamples[j]
 
 			for i := 0; i < iter; i++ {
-				x.MulDivOverflow(&x, &factorsSamples[j], &muldivSamples[j])
+				res := new(Int)
+				res.MulDivOverflow(&x, &x, &muldivSamples[j])
 			}
 		}
 	}
@@ -882,8 +883,9 @@ func BenchmarkMulDivOverflow(b *testing.B) {
 			x := factorsSamples[j]
 
 			for i := 0; i < iter; i++ {
-				x.Mul(&x, &factorsSamples[j])
-				x.Div(&x, &muldivSamples[j])
+				res := new(big.Int)
+				res.Mul(&x, &x)
+				res.Div(res, &muldivSamples[j])
 			}
 		}
 	}


### PR DESCRIPTION
When I saw the original BenchmarkMulDivOverflow shows MulDivOverflow(uint256) is 2 ns and MulDivOverflow(big.Int) is 13 ns,
I knew there's a problem, because div alone would have taken around 20 ns for uint256.

The computation is like this:
```
                      int256SamplesLt[j]           int256SamplesLt[j]
int256SamplesLt[j] * -------------------- ...... * -------------------
                       int256Samples[j]             int256Samples[j]
```
where int256SamplesLt[j] < int256Samples[j].

So within around 1000 iterations, x is reduced to zero, and when x is zero, the function MulDivOverflow directly returns zero, skipping the computation.