### PR TITLE
uint256: optimize leadingZeros and add BenchmarkBitLen

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -944,3 +944,42 @@ func BenchmarkSet(bench *testing.B) {
 	bench.Run("single/uint256", benchmarkUint256)
 	bench.Run("single/big", benchmarkBig)
 }
+
+func BenchmarkBitLen(bench *testing.B) {
+	// res is a variable to prevent the golang compiler from eliminating the benchmark testing entirely.
+	var res int
+
+	data := []Int{
+		{0, 0, 0, 0xffffffffffffffff},
+		{0, 0, 0xffffffffffffffff, 0},
+		{0, 0xffffffffffffffff, 0, 0},
+		{0xffffffffffffffff, 0, 0, 0},
+	}
+
+	benchmarkBitLenUint256 := func(b *testing.B, num *Int) {
+		var r int
+		for i := 0; i < b.N; i++ {
+			r = num.BitLen()
+		}
+		res = r
+	}
+
+	benchmarkBitLenBig := func(b *testing.B, num *big.Int) {
+		var r int
+		for i := 0; i < b.N; i++ {
+			r = num.BitLen()
+		}
+		res = r
+	}
+
+	res += 1
+
+	bench.Run("BitLen192/uint256", func(b *testing.B) { benchmarkBitLenUint256(b, &data[0])})
+	bench.Run("BitLen128/uint256", func(b *testing.B) { benchmarkBitLenUint256(b, &data[1])})
+	bench.Run("BitLen64/uint256", func(b *testing.B) { benchmarkBitLenUint256(b, &data[2])})
+	bench.Run("BitLen0/uint256", func(b *testing.B) { benchmarkBitLenUint256(b, &data[3])})
+	bench.Run("BitLen192/big", func(b *testing.B) { benchmarkBitLenBig(b, data[0].ToBig())})
+	bench.Run("BitLen128/big", func(b *testing.B) { benchmarkBitLenBig(b, data[1].ToBig())})
+	bench.Run("BitLen64/big", func(b *testing.B) { benchmarkBitLenBig(b, data[2].ToBig())})
+	bench.Run("BitLen0/big", func(b *testing.B) { benchmarkBitLenBig(b, data[3].ToBig())})
+}

--- a/mod.go
+++ b/mod.go
@@ -10,13 +10,8 @@ import (
 
 // Some utility functions
 
-func leadingZeros(x *Int) (z int) {
-	var t int
-	z = bits.LeadingZeros64(x[3])
-	t = bits.LeadingZeros64(x[2]); if z ==  64 { z = t +  64 }
-	t = bits.LeadingZeros64(x[1]); if z == 128 { z = t + 128 }
-	t = bits.LeadingZeros64(x[0]); if z == 192 { z = t + 192 }
-	return z
+func leadingZeros(x *Int) int {
+	return 256 - x.BitLen()
 }
 
 // Reciprocal computes a 320-bit value representing 1/m


### PR DESCRIPTION
```
go test ./...
```
returns
```
ok  	github.com/holiman/uint256	0.977s
```

## Bechmark for `leadingZeros`
```
go test -run - -bench BenchmarkLead -benchmem
```
code:
```
func BenchmarkLeadingZeros(bench *testing.B) {
	// res is a variable to prevent the golang compiler from eliminating the benchmark testing entirely.
	var res int

	data := []Int{
		{0, 0, 0, 0xffffffffffffffff},
		{0, 0, 0xffffffffffffffff, 0},
		{0, 0xffffffffffffffff, 0, 0},
		{0xffffffffffffffff, 0, 0, 0},
	}

	benchmarkLeadingZeros := func(b *testing.B, num *Int) {
		var r int
		for i := 0; i < b.N; i++ {
			r = leadingZeros(num)
		}
		res = r
	}

	res += 1

	bench.Run("leadingZeros192/uint256", func(b *testing.B) { benchmarkLeadingZeros(b, &data[0])})
	bench.Run("leadingZeros128/uint256", func(b *testing.B) { benchmarkLeadingZeros(b, &data[1])})
	bench.Run("leadingZeros64/uint256", func(b *testing.B) { benchmarkLeadingZeros(b, &data[2])})
	bench.Run("leadingZeros0/uint256", func(b *testing.B) { benchmarkLeadingZeros(b, &data[3])})
}
```
old:
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
BenchmarkLeadingZeros/leadingZeros192/uint256-16         	238305988	         4.919 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros128/uint256-16         	232537900	         4.886 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros64/uint256-16          	244867848	         5.017 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros0/uint256-16           	244553245	         5.197 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/holiman/uint256	6.845s
```
new:
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
BenchmarkLeadingZeros/leadingZeros192/uint256-16         	1000000000	         1.098 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros128/uint256-16         	906194443	         1.316 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros64/uint256-16          	779154236	         1.565 ns/op	       0 B/op	       0 allocs/op
BenchmarkLeadingZeros/leadingZeros0/uint256-16           	662557696	         1.786 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/holiman/uint256	5.301s
```