### PR TITLE
uint256: optimize AddMod

### DIFF
--- a/conversion_test.go
+++ b/conversion_test.go
@@ -401,7 +401,7 @@ func BenchmarkSetBytes(b *testing.B) {
 			val.SetBytes(bytearr[:27])
 			val.SetBytes(bytearr[:28])
 			val.SetBytes(bytearr[:29])
-			val.SetBytes(bytearr[:20])
+			val.SetBytes(bytearr[:30])
 			val.SetBytes(bytearr[:31])
 			val.SetBytes(bytearr[:32])
 		}

--- a/uint256.go
+++ b/uint256.go
@@ -244,12 +244,10 @@ func (z *Int) AddMod(x, y, m *Int) *Int {
 
 		// final sub was unnecessary
 		if c1 == 0 && c2 != 0 {
-			copy((*z)[:], res[:])
-			return z
+			return z.Set(&res)
 		}
 
-		copy((*z)[:], tmp[:])
-		return z
+		return z.Set(&tmp)
 	}
 
 	if m.IsZero() {


### PR DESCRIPTION
## Test
```
go test ./...
```
```
ok  	github.com/holiman/uint256	1.367s
```
## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                         │     old     │                 new                 │
                         │   sec/op    │   sec/op     vs base                │
AddMod/small/uint256-16    6.292n ± 1%   6.309n ± 1%        ~ (p=0.123 n=10)
AddMod/mod64/uint256-16    10.07n ± 1%   10.02n ± 1%   -0.55% (p=0.049 n=10)
AddMod/mod128/uint256-16   19.14n ± 1%   19.16n ± 1%        ~ (p=0.271 n=10)
AddMod/mod192/uint256-16   20.88n ± 2%   21.09n ± 1%   +1.03% (p=0.050 n=10)
AddMod/mod256/uint256-16   9.728n ± 2%   6.460n ± 1%  -33.59% (p=0.000 n=10)
AddMod/small/big-16        25.80n ± 0%   25.85n ± 0%        ~ (p=0.071 n=10)
AddMod/mod64/big-16        30.18n ± 1%   30.11n ± 0%        ~ (p=0.224 n=10)
AddMod/mod128/big-16       67.25n ± 1%   68.10n ± 0%   +1.26% (p=0.000 n=10)
AddMod/mod192/big-16       68.95n ± 0%   69.28n ± 0%   +0.47% (p=0.005 n=10)
AddMod/mod256/big-16       68.94n ± 1%   69.47n ± 0%   +0.76% (p=0.005 n=10)
geomean                    23.92n        23.04n        -3.69%
```