### PR TITLE
uint256: minor improvement for Mul

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -367,25 +367,22 @@ func umul(x, y *Int, res *[8]uint64) {
 // Mul sets z to the product x*y
 func (z *Int) Mul(x, y *Int) *Int {
 	var (
-		carry                  uint64
-		res0, res1, res2, res3 uint64
+		carry0, carry1, carry2 uint64
+		res1, res2 uint64
+		x0, x1, x2, x3 = x[0], x[1], x[2], x[3]
+		y0, y1, y2, y3 = y[0], y[1], y[2], y[3]
 	)
 
-	carry, res0 = bits.Mul64(x[0], y[0])
-	carry, res1 = umulHop(carry, x[1], y[0])
-	carry, res2 = umulHop(carry, x[2], y[0])
-	res3 = x[3]*y[0] + carry
+	carry0, z[0] = bits.Mul64(x0, y0)
+	carry0, res1 = umulHop(carry0, x1, y0)
+	carry0, res2 = umulHop(carry0, x2, y0)
 
-	carry, res1 = umulHop(res1, x[0], y[1])
-	carry, res2 = umulStep(res2, x[1], y[1], carry)
-	res3 = res3 + x[2]*y[1] + carry
+	carry1, z[1] = umulHop(res1, x0, y1)
+	carry1, res2 = umulStep(res2, x1, y1, carry1)
 
-	carry, res2 = umulHop(res2, x[0], y[2])
-	res3 = res3 + x[1]*y[2] + carry
+	carry2, z[2] = umulHop(res2, x0, y2)
 
-	res3 = res3 + x[0]*y[3]
-
-	z[0], z[1], z[2], z[3] = res0, res1, res2, res3
+	z[3] = x3*y0 + x2*y1 + x0*y3 + x1*y2 + carry0 + carry1 + carry2
 	return z
 }
 


### PR DESCRIPTION
Minor tweek of the code. Not sure where the boost comes from. But it does improve around 10% in my two x86-64 machines.

godbolt links:
old:  https://go.godbolt.org/z/z8vqhG9r7
new: https://go.godbolt.org/z/M17Ycfzxx
## Test
```
go test ./...
```
```
ok  	github.com/holiman/uint256	1.380s
```
## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                      │     old     │                 new                 │
                      │   sec/op    │   sec/op     vs base                │
Mul/single/uint256-16   4.239n ± 2%   3.725n ± 1%  -12.14% (p=0.000 n=10)
Mul/single/big-16       37.05n ± 1%   36.96n ± 2%        ~ (p=0.403 n=10)
geomean                 12.53n        11.73n        -6.38%
```
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: Intel Core Processor (Broadwell, no TSX, IBRS)
                   │     old      │                new                 │
                   │    sec/op    │   sec/op     vs base               │
Mul/single/uint256   10.125n ± 4%   9.346n ± 2%  -7.69% (p=0.000 n=10)
Mul/single/big        79.24n ± 3%   79.11n ± 5%       ~ (p=0.853 n=10)
geomean               28.32n        27.19n       -4.00%
```