### PR TITLE
uint256: optimize div-related functions by removing unnecessary computation

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -246,7 +246,7 @@ func divModMod(z, x, y *Int) *Int {
 func udivremDiv(z, x, y *Int) *Int {
 	var quot Int
 	if !y.IsZero() {
-		udivrem(quot[:], x[:], y)
+		udivrem(quot[:], x[:], y, nil)
 	}
 	return z.Set(&quot)
 }
@@ -256,8 +256,8 @@ func udivremMod(z, x, y *Int) *Int {
 	if y.IsZero() {
 		return z.Clear()
 	}
-	var quot Int
-	rem := udivrem(quot[:], x[:], y)
+	var quot, rem Int
+	udivrem(quot[:], x[:], y, &rem)
 	return z.Set(&rem)
 }
 

--- a/decimal.go
+++ b/decimal.go
@@ -45,8 +45,8 @@ func (z *Int) Dec() string {
 	)
 	for {
 		// Obtain Q and R for divisor
-		var quot Int
-		rem := udivrem(quot[:], y[:], divisor)
+		var quot, rem Int
+		udivrem(quot[:], y[:], divisor, &rem)
 		y.Set(&quot) // Set Q for next loop
 		// Convert the R to ascii representation
 		buf = strconv.AppendUint(buf[:0], rem.Uint64(), 10)
@@ -79,8 +79,8 @@ func (z *Int) PrettyDec(separator byte) string {
 		comma   = 0
 	)
 	for {
-		var quot Int
-		rem := udivrem(quot[:], y[:], divisor)
+		var quot, rem Int
+		rem := udivrem(quot[:], y[:], divisor, &rem)
 		y.Set(&quot) // Set Q for next loop
 		buf = strconv.AppendUint(buf[:0], rem.Uint64(), 10)
 		for j := len(buf) - 1; j >= 0; j-- {

--- a/decimal.go
+++ b/decimal.go
@@ -80,7 +80,7 @@ func (z *Int) PrettyDec(separator byte) string {
 	)
 	for {
 		var quot, rem Int
-		rem := udivrem(quot[:], y[:], divisor, &rem)
+		udivrem(quot[:], y[:], divisor, &rem)
 		y.Set(&quot) // Set Q for next loop
 		buf = strconv.AppendUint(buf[:0], rem.Uint64(), 10)
 		for j := len(buf) - 1; j >= 0; j-- {

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -479,8 +479,9 @@ func TestUdivremQuick(t *testing.T) {
 	var (
 		u        = []uint64{1, 0, 0, 0, 0}
 		expected = new(Int)
+		rem Int
 	)
-	rem := udivrem([]uint64{}, u, &Int{0, 1, 0, 0})
+	udivrem([]uint64{}, u, &Int{0, 1, 0, 0}, &rem)
 	copy(expected[:], u)
 	if !rem.Eq(expected) {
 		t.Errorf("Wrong remainder: %x, expected %x", rem, expected)


### PR DESCRIPTION
The functions `Div`, `SDiv` and `MulDivOverflow` don't need the remainder, so we change the api of `udivrem` to pass nil to skip the last part of the computatoin of `rem`. This PR doesn't affect the computation of quotient `quot`.

# Test
```
go test ./...
```
```
ok  	github.com/holiman/uint256	1.366s
```
## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                                 │     old      │                 new                 │
                                 │    sec/op    │   sec/op     vs base                │
Div/small/uint256-16                3.105n ± 0%   3.105n ± 1%        ~ (p=0.988 n=10)
Div/mod64/uint256-16                21.57n ± 2%   21.20n ± 2%   -1.72% (p=0.017 n=10)
Div/mod128/uint256-16               38.65n ± 2%   37.28n ± 1%   -3.53% (p=0.000 n=10)
Div/mod192/uint256-16               34.94n ± 1%   32.80n ± 2%   -6.14% (p=0.000 n=10)
Div/mod256/uint256-16               27.29n ± 1%   23.99n ± 1%  -12.08% (p=0.000 n=10)
Mod/small/uint256-16                4.065n ± 2%   4.082n ± 1%        ~ (p=0.617 n=10)
Mod/mod64/uint256-16                27.16n ± 2%   22.75n ± 1%  -16.24% (p=0.000 n=10)
Mod/mod128/uint256-16               40.44n ± 2%   39.97n ± 2%        ~ (p=0.060 n=10)
Mod/mod192/uint256-16               36.69n ± 1%   36.53n ± 0%        ~ (p=0.101 n=10)
Mod/mod256/uint256-16               28.71n ± 1%   28.48n ± 2%   -0.78% (p=0.001 n=10)
AddMod/small/uint256-16             6.372n ± 2%   6.205n ± 2%   -2.63% (p=0.000 n=10)
AddMod/mod64/uint256-16            10.080n ± 1%   9.048n ± 0%  -10.23% (p=0.000 n=10)
AddMod/mod128/uint256-16            18.88n ± 2%   18.15n ± 1%   -3.84% (p=0.000 n=10)
AddMod/mod192/uint256-16            20.69n ± 1%   19.75n ± 0%   -4.54% (p=0.000 n=10)
AddMod/mod256/uint256-16            6.434n ± 1%   6.457n ± 1%   +0.36% (p=0.020 n=10)
MulMod/small/uint256-16             17.61n ± 1%   15.95n ± 1%   -9.40% (p=0.000 n=10)
MulMod/mod64/uint256-16             36.81n ± 2%   29.49n ± 1%  -19.88% (p=0.000 n=10)
MulMod/mod128/uint256-16            56.83n ± 2%   52.33n ± 1%   -7.91% (p=0.000 n=10)
MulMod/mod192/uint256-16            71.45n ± 2%   66.25n ± 1%   -7.28% (p=0.000 n=10)
MulMod/mod256/uint256-16            87.00n ± 1%   86.02n ± 1%        ~ (p=0.190 n=10)
MulMod/mod256/uint256r-16           37.83n ± 2%   37.84n ± 2%        ~ (p=0.839 n=10)
SDiv/large/uint256-16               35.52n ± 1%   33.66n ± 1%   -5.25% (p=0.000 n=10)
MulDivOverflow/small/uint256-16     22.30n ± 2%   21.40n ± 1%   -4.06% (p=0.000 n=10)
MulDivOverflow/div64/uint256-16     27.43n ± 1%   24.33n ± 1%  -11.29% (p=0.000 n=10)
MulDivOverflow/div128/uint256-16    41.56n ± 0%   39.32n ± 2%   -5.40% (p=0.000 n=10)
MulDivOverflow/div192/uint256-16    53.98n ± 1%   50.98n ± 1%   -5.57% (p=0.000 n=10)
MulDivOverflow/div256/uint256-16    69.49n ± 1%   65.30n ± 1%   -6.04% (p=0.000 n=10)
geomean                             24.99n        23.61n        -5.54%
```