### PR TITLE
uint256: optimize MulMod, MulModWithReciprocal

### DIFF
--- a/mod.go
+++ b/mod.go
@@ -330,8 +330,8 @@ func Reciprocal(m *Int) (mu [5]uint64) {
 
 // reduce4 computes the least non-negative residue of x modulo m
 //
-// requires a four-word modulus (m[3] > 1) and its inverse (mu)
-func reduce4(x [8]uint64, m *Int, mu [5]uint64) (z Int) {
+// requires a four-word modulus (m[3] != 0) and its inverse (mu)
+func (z *Int) reduce4(x *[8]uint64, m *Int, mu *[5]uint64) *Int {
 
 	// NB: Most variable names in the comments match the pseudocode for
 	// 	Barrett reduction in the Handbook of Applied Cryptography.

--- a/uint256.go
+++ b/uint256.go
@@ -679,8 +679,7 @@ func (z *Int) MulModWithReciprocal(x, y, m *Int, mu *[5]uint64) *Int {
 	umul(x, y, &p)
 
 	if m[3] != 0 {
-		r := reduce4(p, m, *mu)
-		return z.Set(&r)
+		return z.reduce4(&p, m, mu)
 	}
 
 	var (
@@ -713,8 +712,7 @@ func (z *Int) MulMod(x, y, m *Int) *Int {
 
 	if m[3] != 0 {
 		mu := Reciprocal(m)
-		r := reduce4(p, m, mu)
-		return z.Set(&r)
+		return z.reduce4(&p, m, &mu)
 	}
 
 	var (


### PR DESCRIPTION
The api of `reduce4` is changed to reduce array copies.

1. The function `reduce4` doesn't change the values of its parameters `x`, `m`, and `mu`. So it's fine to pass by pointers.
2. In the case of `z == m` (They are alias), `m` is used before `z`, and `z` is only written in the last step. So this is fine too.

## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                          │     old     │                 new                 │
                          │   sec/op    │   sec/op     vs base                │
MulMod/small/uint256-16     15.84n ± 2%   15.63n ± 1%   -1.33% (p=0.049 n=10)
MulMod/mod64/uint256-16     29.44n ± 1%   29.09n ± 2%   -1.17% (p=0.030 n=10)
MulMod/mod128/uint256-16    51.92n ± 1%   52.62n ± 2%        ~ (p=0.183 n=10)
MulMod/mod192/uint256-16    66.39n ± 2%   65.42n ± 1%        ~ (p=0.086 n=10)
MulMod/mod256/uint256-16    87.02n ± 2%   77.26n ± 1%  -11.20% (p=0.000 n=10)
MulMod/mod256/uint256r-16   38.07n ± 2%   27.52n ± 2%  -27.70% (p=0.000 n=10)
geomean                     41.79n        38.64n        -7.53%
```