### PR TITLE
uint256: optimize Mod, DivMod, AddMod

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -705,6 +705,36 @@ func BenchmarkMod(b *testing.B) {
 	b.Run("mod256/big", func(b *testing.B) { benchmarkModBig(b, &big256Samples, &big256SamplesLt) })
 }
 
+func BenchmarkDivMod(b *testing.B) {
+	benchmarkDivModUint256 := func(b *testing.B, xSamples, modSamples *[numSamples]Int) {
+		var sink, mod Int
+		for j := 0; j < b.N; j += numSamples {
+			for i := 0; i < numSamples; i++ {
+				sink.DivMod(&xSamples[i], &modSamples[i], &mod)
+			}
+		}
+	}
+	benchmarkDivModBig := func(b *testing.B, xSamples, modSamples *[numSamples]big.Int) {
+		var sink, mod big.Int
+		for j := 0; j < b.N; j += numSamples {
+			for i := 0; i < numSamples; i++ {
+				sink.DivMod(&xSamples[i], &modSamples[i], &mod)
+			}
+		}
+	}
+
+	b.Run("small/uint256", func(b *testing.B) { benchmarkDivModUint256(b, &int32Samples, &int32SamplesLt) })
+	b.Run("mod64/uint256", func(b *testing.B) { benchmarkDivModUint256(b, &int256Samples, &int64Samples) })
+	b.Run("mod128/uint256", func(b *testing.B) { benchmarkDivModUint256(b, &int256Samples, &int128Samples) })
+	b.Run("mod192/uint256", func(b *testing.B) { benchmarkDivModUint256(b, &int256Samples, &int192Samples) })
+	b.Run("mod256/uint256", func(b *testing.B) { benchmarkDivModUint256(b, &int256Samples, &int256SamplesLt) })
+	b.Run("small/big", func(b *testing.B) { benchmarkDivModBig(b, &big32Samples, &big32SamplesLt) })
+	b.Run("mod64/big", func(b *testing.B) { benchmarkDivModBig(b, &big256Samples, &big64Samples) })
+	b.Run("mod128/big", func(b *testing.B) { benchmarkDivModBig(b, &big256Samples, &big128Samples) })
+	b.Run("mod192/big", func(b *testing.B) { benchmarkDivModBig(b, &big256Samples, &big192Samples) })
+	b.Run("mod256/big", func(b *testing.B) { benchmarkDivModBig(b, &big256Samples, &big256SamplesLt) })
+}
+
 func BenchmarkAddMod(b *testing.B) {
 	benchmarkAddModUint256 := func(b *testing.B, factorsSamples, modSamples *[numSamples]Int) {
 		iter := (b.N + numSamples - 1) / numSamples

--- a/uint256.go
+++ b/uint256.go
@@ -586,18 +586,12 @@ func (z *Int) Div(x, y *Int) *Int {
 // Mod sets z to the modulus x%y for y != 0 and returns z.
 // If y == 0, z is set to 0 (OBS: differs from the big.Int)
 func (z *Int) Mod(x, y *Int) *Int {
-	if x.IsZero() || y.IsZero() {
+	if y.IsZero() || x.Eq(y) {
 		return z.Clear()
 	}
-	switch x.Cmp(y) {
-	case -1:
-		// x < y
+	if x.Lt(y) {
 		return z.Set(x)
-	case 0:
-		// x == y
-		return z.Clear() // They are equal
 	}
-
 	// At this point:
 	// x != 0
 	// y != 0
@@ -619,14 +613,11 @@ func (z *Int) DivMod(x, y, m *Int) (*Int, *Int) {
 	if y.IsZero() {
 		return z.Clear(), m.Clear()
 	}
-
-	switch x.Cmp(y) {
-	case -1:
-		// x < y
-		return z.Clear(), m.Set(x)
-	case 0:
-		// x == y
+	if x.Eq(y) {
 		return z.SetOne(), m.Clear()
+	}
+	if x.Lt(y) {
+		return z.Clear(), m.Set(x)
 	}
 
 	// At this point:


### PR DESCRIPTION
`Lt` is branchless and can be inlined, while `Cmp` has two `if` branches and can not be inlined. So `Lt` is better.

To check if a simple function can be inlined or not in golang, run
```
go build -gcflags='-m -m' |& grep Lt
```
Learn this trick a few days ago.
## Benchmark
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: AMD Ryzen 7 7735H with Radeon Graphics         
                         │     old     │                 new                 │
                         │   sec/op    │   sec/op     vs base                │
Mod/small/uint256-16       4.041n ± 2%   2.865n ± 1%  -29.10% (p=0.000 n=10)
Mod/mod64/uint256-16       22.68n ± 1%   21.39n ± 2%   -5.69% (p=0.000 n=10)
Mod/mod128/uint256-16      39.82n ± 1%   38.23n ± 1%   -4.01% (p=0.000 n=10)
Mod/mod192/uint256-16      36.37n ± 1%   34.69n ± 2%   -4.62% (p=0.000 n=10)
Mod/mod256/uint256-16      28.33n ± 1%   27.08n ± 1%   -4.39% (p=0.000 n=10)
DivMod/small/uint256-16    4.445n ± 1%   3.121n ± 3%  -29.80% (p=0.000 n=10)
DivMod/mod64/uint256-16    22.95n ± 1%   22.12n ± 2%   -3.64% (p=0.000 n=10)
DivMod/mod128/uint256-16   40.21n ± 2%   39.35n ± 0%   -2.16% (p=0.001 n=10)
DivMod/mod192/uint256-16   36.58n ± 2%   35.75n ± 1%   -2.26% (p=0.000 n=10)
DivMod/mod256/uint256-16   28.75n ± 1%   27.68n ± 2%   -3.70% (p=0.000 n=10)
AddMod/small/uint256-16    6.158n ± 2%   4.748n ± 0%  -22.90% (p=0.000 n=10)
AddMod/mod64/uint256-16    9.024n ± 2%   7.413n ± 1%  -17.86% (p=0.000 n=10)
AddMod/mod128/uint256-16   18.00n ± 2%   15.86n ± 1%  -11.89% (p=0.000 n=10)
AddMod/mod192/uint256-16   19.78n ± 2%   17.61n ± 2%  -10.97% (p=0.000 n=10)
AddMod/mod256/uint256-16   6.416n ± 2%   6.422n ± 1%        ~ (p=0.928 n=10)
geomean                    16.63n        14.84n       -10.76%
```