### PR TITLE
conversion: introduce 0-alloc IntoBig method

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -968,7 +968,6 @@ func BenchmarkHashTreeRoot(b *testing.B) {
 }
 
 func BenchmarkSet(bench *testing.B) {
-
 	benchmarkUint256 := func(bench *testing.B) {
 		a := new(Int).SetBytes(hex2Bytes("f123456789abcdeffedcba9876543210f2f3f4f5f6f7f8f9fff3f4f5f6f7f8f9"))
 

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -324,6 +324,28 @@ func BenchmarkToBig(bench *testing.B) {
 	bench.Run("4words", func(bench *testing.B) { benchToBig(bench, param4) })
 }
 
+func benchIntoBig(bench *testing.B, f *Int) *big.Int {
+	var b *big.Int
+	for i := 0; i < bench.N; i++ {
+		f.IntoBig(&b)
+	}
+	return b
+}
+
+func BenchmarkIntoBig(bench *testing.B) {
+	param1 := new(Int).SetUint64(0xff)
+	bench.Run("1word", func(bench *testing.B) { benchIntoBig(bench, param1) })
+
+	param2 := new(Int).Lsh(param1, 64)
+	bench.Run("2words", func(bench *testing.B) { benchIntoBig(bench, param2) })
+
+	param3 := new(Int).Lsh(param2, 64)
+	bench.Run("3words", func(bench *testing.B) { benchIntoBig(bench, param3) })
+
+	param4 := new(Int).Lsh(param3, 64)
+	bench.Run("4words", func(bench *testing.B) { benchIntoBig(bench, param4) })
+}
+
 func TestFormat(t *testing.T) {
 	testCases := []string{
 		"0",

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -243,6 +243,30 @@ func TestToBig(t *testing.T) {
 	}
 }
 
+func TestIntoBig(t *testing.T) {
+	var uint256Nil *Int
+
+	bigNil := new(big.Int)
+	if uint256Nil.IntoBig(&bigNil); bigNil != nil {
+		t.Errorf("want big.Int <nil>, have %x", bigNil)
+	}
+	var bigZero *big.Int
+	if new(Int).IntoBig(&bigZero); bigZero.Cmp(new(big.Int)) != 0 {
+		t.Errorf("expected big.Int 0, got %x", bigZero)
+	}
+	var b *big.Int
+	for i := uint(0); i < 256; i++ {
+		f := new(Int).SetUint64(1)
+		f.Lsh(f, i)
+		f.IntoBig(&b)
+		expected := big.NewInt(1)
+		expected.Lsh(expected, i)
+		if b.Cmp(expected) != 0 {
+			t.Fatalf("expected %x, got %x", expected, b)
+		}
+	}
+}
+
 func BenchmarkScanScientific(b *testing.B) {
 	intsub1 := new(Int)
 	_ = intsub1.fromDecimal(twoPow256Sub1)


### PR DESCRIPTION
Fixes https://github.com/holiman/uint256/issues/176

TL;DR: `ToBig` does 2x32 byte allocations. Once to create a new big.Int and a second time to seed the contents of the big.Int. This PR adds `IntoBig` (to avoid breaking the API) which takes an input big.Int, and if it has a large enough internal buffer, it will use that for conversion instead of reallocating.

If the big.Int is nil, it will be allocated (32 byte) and if it's not large enough, it's data space will be allocated (32 byte).

Bechmarks:

```
goos: darwin
goarch: arm64
pkg: github.com/holiman/uint256
BenchmarkToBig/1word-12         	35593915	        33.95 ns/op	      64 B/op	       2 allocs/op
BenchmarkToBig/2words-12        	35652079	        33.95 ns/op	      64 B/op	       2 allocs/op
BenchmarkToBig/3words-12        	36683552	        33.47 ns/op	      64 B/op	       2 allocs/op
BenchmarkToBig/4words-12        	36919052	        33.22 ns/op	      64 B/op	       2 allocs/op
BenchmarkIntoBig/1word-12       	341185051	         3.467 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntoBig/2words-12      	375558397	         3.194 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntoBig/3words-12      	460186147	         2.653 ns/op	       0 B/op	       0 allocs/op
BenchmarkIntoBig/4words-12      	511418574	         2.368 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/holiman/uint256	12.132s
```