### PR TITLE
optimize `Exp` for even bases

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -572,10 +572,7 @@ func bigExp(result, base, exponent *big.Int) *big.Int {
 	return result
 }
 
-func benchmark_Exp_Big(bench *testing.B) {
-	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-
+func benchmark_Exp_Big(bench *testing.B, x, y string) {
 	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
 	base := big.NewInt(0).SetBytes(hex2Bytes(x))
 	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
@@ -588,133 +585,54 @@ func benchmark_Exp_Big(bench *testing.B) {
 	}
 }
 
-func benchmark_ExpEven_Big(bench *testing.B) {
-	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
-	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+func benchmark_Exp_U256(bench *testing.B, x, y string) {
+	var (
+		base = big.NewInt(0).SetBytes(hex2Bytes(x))
+		exp  = big.NewInt(0).SetBytes(hex2Bytes(y))
 
-	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	result := new(big.Int)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		bigExp(result, base, exp)
-		base.Set(orig)
-	}
-}
-
-func benchmark_Exp_Bit(bench *testing.B) {
-	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	f_base, _ := FromBig(base)
-	f_orig, _ := FromBig(base)
-	f_exp, _ := FromBig(exp)
-	f_res := Int{}
-
+		f_base, _ = FromBig(base)
+		f_orig, _ = FromBig(base)
+		f_exp, _  = FromBig(exp)
+		f_res     Int
+	)
 	bench.ResetTimer()
 	for i := 0; i < bench.N; i++ {
 		f_res.Exp(f_base, f_exp)
 		f_base.Set(f_orig)
 	}
 }
-func benchmark_ExpEven_Bit(bench *testing.B) {
-	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
-	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
 
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	f_base, _ := FromBig(base)
-	f_orig, _ := FromBig(base)
-	f_exp, _ := FromBig(exp)
-	f_res := Int{}
-
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		f_res.Exp(f_base, f_exp)
-		f_base.Set(f_orig)
-	}
-}
-func benchmark_ExpSmall_Big(bench *testing.B) {
-	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-	y := "8abcdef"
-
-	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	result := new(big.Int)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		bigExp(result, base, exp)
-		base.Set(orig)
-	}
-}
-func benchmark_ExpSmallEven_Big(bench *testing.B) {
-	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
-	y := "8abcdef"
-
-	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	result := new(big.Int)
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		bigExp(result, base, exp)
-		base.Set(orig)
-	}
-}
-func benchmark_ExpSmall_Bit(bench *testing.B) {
-	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
-	y := "8abcdef"
-
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	f_base, _ := FromBig(base)
-	f_orig, _ := FromBig(base)
-	f_exp, _ := FromBig(exp)
-	f_res := Int{}
-
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		f_res.Exp(f_base, f_exp)
-		f_base.Set(f_orig)
-	}
-}
-func benchmark_ExpSmallEven_Bit(bench *testing.B) {
-	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
-	y := "8abcdef"
-
-	base := big.NewInt(0).SetBytes(hex2Bytes(x))
-	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
-
-	f_base, _ := FromBig(base)
-	f_orig, _ := FromBig(base)
-	f_exp, _ := FromBig(exp)
-	f_res := Int{}
-
-	bench.ResetTimer()
-	for i := 0; i < bench.N; i++ {
-		f_res.Exp(f_base, f_exp)
-		f_base.Set(f_orig)
-	}
-}
 func BenchmarkExp(bench *testing.B) {
-	bench.Run("large/big", benchmark_Exp_Big)
-	bench.Run("large/even/big", benchmark_ExpEven_Big)
-	bench.Run("large/uint256", benchmark_Exp_Bit)
-	bench.Run("large/even/uint256", benchmark_ExpEven_Bit)
-	bench.Run("small/big", benchmark_ExpSmall_Big)
-	bench.Run("small/even/big", benchmark_ExpSmallEven_Big)
-	bench.Run("small/uint256", benchmark_ExpSmall_Bit)
-	bench.Run("small/even/uint256", benchmark_ExpSmallEven_Bit)
+	{ // Large values
+		base := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+		exp := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+		bench.Run("large/big", func(b *testing.B) {
+			benchmark_Exp_Big(b, base, exp)
+		})
+		bench.Run("large/uint256", func(b *testing.B) {
+			benchmark_Exp_U256(b, base, exp)
+		})
+	}
+	{ // Smaller exponent
+		base := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+		exp := "8abcdef"
+		bench.Run("small/big", func(b *testing.B) {
+			benchmark_Exp_Big(b, base, exp)
+		})
+		bench.Run("small/uint256", func(b *testing.B) {
+			benchmark_Exp_U256(b, base, exp)
+		})
+	}
+	{ // Even base (and very small exponent)
+		base := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
+		exp := "ff"
+		bench.Run("even/big", func(b *testing.B) {
+			benchmark_Exp_Big(b, base, exp)
+		})
+		bench.Run("even/uint256", func(b *testing.B) {
+			benchmark_Exp_U256(b, base, exp)
+		})
+	}
 }
 
 func BenchmarkDiv(b *testing.B) {

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -587,8 +587,43 @@ func benchmark_Exp_Big(bench *testing.B) {
 		base.Set(orig)
 	}
 }
+
+func benchmark_ExpEven_Big(bench *testing.B) {
+	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
+	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+
+	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
+	base := big.NewInt(0).SetBytes(hex2Bytes(x))
+	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
+
+	result := new(big.Int)
+	bench.ResetTimer()
+	for i := 0; i < bench.N; i++ {
+		bigExp(result, base, exp)
+		base.Set(orig)
+	}
+}
+
 func benchmark_Exp_Bit(bench *testing.B) {
 	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
+
+	base := big.NewInt(0).SetBytes(hex2Bytes(x))
+	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
+
+	f_base, _ := FromBig(base)
+	f_orig, _ := FromBig(base)
+	f_exp, _ := FromBig(exp)
+	f_res := Int{}
+
+	bench.ResetTimer()
+	for i := 0; i < bench.N; i++ {
+		f_res.Exp(f_base, f_exp)
+		f_base.Set(f_orig)
+	}
+}
+func benchmark_ExpEven_Bit(bench *testing.B) {
+	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
 	y := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
 
 	base := big.NewInt(0).SetBytes(hex2Bytes(x))
@@ -620,6 +655,21 @@ func benchmark_ExpSmall_Big(bench *testing.B) {
 		base.Set(orig)
 	}
 }
+func benchmark_ExpSmallEven_Big(bench *testing.B) {
+	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
+	y := "8abcdef"
+
+	orig := big.NewInt(0).SetBytes(hex2Bytes(x))
+	base := big.NewInt(0).SetBytes(hex2Bytes(x))
+	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
+
+	result := new(big.Int)
+	bench.ResetTimer()
+	for i := 0; i < bench.N; i++ {
+		bigExp(result, base, exp)
+		base.Set(orig)
+	}
+}
 func benchmark_ExpSmall_Bit(bench *testing.B) {
 	x := "ABCDEF090807060504030201ffffffffffffffffffffffffffffffffffffffff"
 	y := "8abcdef"
@@ -638,11 +688,33 @@ func benchmark_ExpSmall_Bit(bench *testing.B) {
 		f_base.Set(f_orig)
 	}
 }
+func benchmark_ExpSmallEven_Bit(bench *testing.B) {
+	x := "ABCDEF090807060504030201fffffffffffffffffffffffffffffffffffffffe"
+	y := "8abcdef"
+
+	base := big.NewInt(0).SetBytes(hex2Bytes(x))
+	exp := big.NewInt(0).SetBytes(hex2Bytes(y))
+
+	f_base, _ := FromBig(base)
+	f_orig, _ := FromBig(base)
+	f_exp, _ := FromBig(exp)
+	f_res := Int{}
+
+	bench.ResetTimer()
+	for i := 0; i < bench.N; i++ {
+		f_res.Exp(f_base, f_exp)
+		f_base.Set(f_orig)
+	}
+}
 func BenchmarkExp(bench *testing.B) {
 	bench.Run("large/big", benchmark_Exp_Big)
+	bench.Run("large/even/big", benchmark_ExpEven_Big)
 	bench.Run("large/uint256", benchmark_Exp_Bit)
+	bench.Run("large/even/uint256", benchmark_ExpEven_Bit)
 	bench.Run("small/big", benchmark_ExpSmall_Big)
+	bench.Run("small/even/big", benchmark_ExpSmallEven_Big)
 	bench.Run("small/uint256", benchmark_ExpSmall_Bit)
+	bench.Run("small/even/uint256", benchmark_ExpSmallEven_Bit)
 }
 
 func BenchmarkDiv(b *testing.B) {

--- a/uint256.go
+++ b/uint256.go
@@ -1188,6 +1188,21 @@ func (z *Int) Exp(base, exponent *Int) *Int {
 
 	curBit := 0
 	word := exponent[0]
+
+	if base[0]&1 == 0 {
+		if expBitLen > 8 {
+			return z.Clear()
+		}
+		for ; curBit < expBitLen; curBit++ {
+			if word&1 == 1 {
+				res.Mul(&res, &multiplier)
+			}
+			multiplier.squared()
+			word >>= 1
+		}
+		return z.Set(&res)
+	}
+
 	for ; curBit < expBitLen && curBit < 64; curBit++ {
 		if word&1 == 1 {
 			res.Mul(&res, &multiplier)


### PR DESCRIPTION
full benchstat:

```goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz
                         │    old.txt     │               new.txt               │
                         │     sec/op     │   sec/op     vs base                │
Exp/large/big-2               21.01µ ± 8%   21.60µ ± 5%        ~ (p=0.393 n=10)
Exp/large/even/big-2          6.033µ ± 6%   6.133µ ± 6%        ~ (p=0.353 n=10)
Exp/large/uint256-2           2.311µ ± 4%   2.348µ ± 5%        ~ (p=0.315 n=10)
Exp/large/even/uint256-2   2279.500n ± 4%   6.894n ± 3%  -99.70% (p=0.000 n=10)
Exp/small/big-2               7.050µ ± 8%   6.753µ ± 3%        ~ (p=0.579 n=10)
Exp/small/even/big-2          1.979µ ± 6%   1.982µ ± 6%        ~ (p=0.684 n=10)
Exp/small/uint256-2           200.0n ± 4%   205.8n ± 5%        ~ (p=0.853 n=10)
Exp/small/even/uint256-2    206.300n ± 4%   7.024n ± 5%  -96.60% (p=0.000 n=10)
geomean                       2.104µ        671.8n       -68.07%

                         │    old.txt     │                new.txt                │
                         │      B/op      │     B/op      vs base                 │
Exp/large/big-2            17.72Ki ± 0%     17.72Ki ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/even/big-2       1.391Ki ± 0%     1.391Ki ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/uint256-2          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/even/uint256-2     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/big-2            7.219Ki ± 0%     7.219Ki ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/even/big-2       1.203Ki ± 0%     1.203Ki ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/uint256-2          0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/even/uint256-2     0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                 ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                         │   old.txt    │               new.txt               │
                         │  allocs/op   │ allocs/op   vs base                 │
Exp/large/big-2            189.0 ± 0%     189.0 ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/even/big-2       15.00 ± 0%     15.00 ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/uint256-2        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/large/even/uint256-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/big-2            77.00 ± 0%     77.00 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/even/big-2       13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/uint256-2        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Exp/small/even/uint256-2   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                               ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

```

closes #188 