### PR TITLE
uint256: optimize WriteToArray

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1020,3 +1020,33 @@ func BenchmarkExtendSign(b *testing.B) {
 		result.ExtendSign(a, n)
 	}
 }
+
+func BenchmarkWriteToArray20(b *testing.B) { benchmarkWriteToArray(b, true) }
+func BenchmarkWriteToArray32(b *testing.B) { benchmarkWriteToArray(b, false) }
+
+func benchmarkWriteToArray(b *testing.B, isWrite20 bool) {
+	x1 := hex2Bytes("0000000000000000000000000000d1e870eec79504c60144cc7f5fc2bad1e611")
+	a := big.NewInt(0).SetBytes(x1)
+	fa, _ := FromBig(a)
+
+	if isWrite20 {
+		dest := [20]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			fa.WriteToArray20(&dest)
+		}
+		b.StopTimer()
+		// Avoid the compiler to optimize out the WriteToArray20
+		_ = (string(dest[:]))
+	} else {
+		dest := [32]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			fa.WriteToArray32(&dest)
+		}
+		b.StopTimer()
+		// Avoid the compiler to optimize out the WriteToArray32
+		_ = (string(dest[:]))
+	}
+}

--- a/uint256.go
+++ b/uint256.go
@@ -144,6 +144,19 @@ func (z *Int) WriteToSlice(dest []byte) {
 	}
 }
 
+// PutUint256 writes all 32 bytes of z to the destination slice, including zero-bytes.
+// If dest is larger than 32 bytes, z will fill the first parts, and leave
+// the end untouched.
+// Note: The dest slice must be at least 32 bytes large, otherwise this
+// method will panic. The method WriteToSlice, which is slower,  should be used
+// if the destination slice is smaller or of unknown size.
+func (z *Int) PutUint256(dest []byte) {
+	binary.BigEndian.PutUint64(dest[0:8], z[3])
+	binary.BigEndian.PutUint64(dest[8:16], z[2])
+	binary.BigEndian.PutUint64(dest[16:24], z[1])
+	binary.BigEndian.PutUint64(dest[24:32], z[0])
+}
+
 // WriteToArray32 writes all 32 bytes of z to the destination array, including zero-bytes
 func (z *Int) WriteToArray32(dest *[32]byte) {
 	// The PutUint64()s are inlined and we get 4x (load, bswap, store) instructions.

--- a/uint256.go
+++ b/uint256.go
@@ -151,6 +151,7 @@ func (z *Int) WriteToSlice(dest []byte) {
 // method will panic. The method WriteToSlice, which is slower,  should be used
 // if the destination slice is smaller or of unknown size.
 func (z *Int) PutUint256(dest []byte) {
+	_ = dest[31]
 	binary.BigEndian.PutUint64(dest[0:8], z[3])
 	binary.BigEndian.PutUint64(dest[8:16], z[2])
 	binary.BigEndian.PutUint64(dest[16:24], z[1])

--- a/uint256.go
+++ b/uint256.go
@@ -146,16 +146,19 @@ func (z *Int) WriteToSlice(dest []byte) {
 
 // WriteToArray32 writes all 32 bytes of z to the destination array, including zero-bytes
 func (z *Int) WriteToArray32(dest *[32]byte) {
-	for i := 0; i < 32; i++ {
-		dest[31-i] = byte(z[i/8] >> uint64(8*(i%8)))
-	}
+	// The PutUint64()s are inlined and we get 4x (load, bswap, store) instructions.
+	binary.BigEndian.PutUint64(dest[0:8], z[3])
+	binary.BigEndian.PutUint64(dest[8:16], z[2])
+	binary.BigEndian.PutUint64(dest[16:24], z[1])
+	binary.BigEndian.PutUint64(dest[24:32], z[0])
 }
 
 // WriteToArray20 writes the last 20 bytes of z to the destination array, including zero-bytes
 func (z *Int) WriteToArray20(dest *[20]byte) {
-	for i := 0; i < 20; i++ {
-		dest[19-i] = byte(z[i/8] >> uint64(8*(i%8)))
-	}
+	// The PutUint*()s are inlined and we get 3x (load, bswap, store) instructions.
+	binary.BigEndian.PutUint32(dest[0:4], uint32(z[2]))
+	binary.BigEndian.PutUint64(dest[4:12], z[1])
+	binary.BigEndian.PutUint64(dest[12:20], z[0])
 }
 
 // Uint64 returns the lower 64-bits of z

--- a/uint256_test.go
+++ b/uint256_test.go
@@ -479,7 +479,7 @@ func TestUdivremQuick(t *testing.T) {
 	var (
 		u        = []uint64{1, 0, 0, 0, 0}
 		expected = new(Int)
-		rem Int
+		rem      Int
 	)
 	udivrem([]uint64{}, u, &Int{0, 1, 0, 0}, &rem)
 	copy(expected[:], u)
@@ -760,30 +760,37 @@ func TestWriteToSlice(t *testing.T) {
 	}
 
 }
+
 func TestInt_WriteToArray(t *testing.T) {
-	x1 := hex2Bytes("0000000000000000000000000000d1e870eec79504c60144cc7f5fc2bad1e611")
+	x1 := hex2Bytes("0102030405060708090a0b0c0d0ed1e870eec79504c60144cc7f5fc2bad1e611")
 	a := big.NewInt(0).SetBytes(x1)
 	fa, _ := FromBig(a)
 
 	{
 		dest := [20]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 		fa.WriteToArray20(&dest)
-		exp := hex2Bytes("0000d1e870eec79504c60144cc7f5fc2bad1e611")
+		exp := hex2Bytes("0d0ed1e870eec79504c60144cc7f5fc2bad1e611")
 		if !bytes.Equal(dest[:], exp) {
 			t.Errorf("got %x, expected %x", dest, exp)
 		}
-
 	}
-
 	{
 		dest := [32]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
 		fa.WriteToArray32(&dest)
-		exp := hex2Bytes("0000000000000000000000000000d1e870eec79504c60144cc7f5fc2bad1e611")
+		exp := hex2Bytes("0102030405060708090a0b0c0d0ed1e870eec79504c60144cc7f5fc2bad1e611")
 		if !bytes.Equal(dest[:], exp) {
 			t.Errorf("got %x, expected %x", dest, exp)
 		}
-
+	}
+	{ // A 36-byte slice: the first 32 bytes are overwritten
+		dest := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+		fa.PutUint256(dest)
+		exp := hex2Bytes("0102030405060708090a0b0c0d0ed1e870eec79504c60144cc7f5fc2bad1e611ffffffff")
+		if !bytes.Equal(dest[:], exp) {
+			t.Errorf("got %x, expected %x", dest, exp)
+		}
 	}
 }
 


### PR DESCRIPTION
Make WriteToArray32 and WriteToArray20 use PutUint64 like in Bytes32 and Bytes20 to remove all branches and increase the number of bytes per 1 load/store to 8 bytes.
```
goos: linux
goarch: amd64
pkg: github.com/holiman/uint256
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
                 │    old.txt     │                new.txt                │
                 │     sec/op     │    sec/op      vs base                │
WriteToArray20-8   31.8000n ± 15%   0.7819n ± 17%  -97.54% (p=0.000 n=10)
WriteToArray32-8    57.640n ± 22%    1.050n ± 18%  -98.18% (p=0.000 n=10)
geomean              42.81n         0.9059n        -97.88%
```
By changing Memory.Set32 in go-ethereum to use new WriteToArray32 we can reduce a memory copy which makes OpMstore faster.

The patch
```
diff --git a/core/vm/memory.go b/core/vm/memory.go index 1ddd8d1ea..58d6f7383 100644
--- a/core/vm/memory.go
+++ b/core/vm/memory.go
@@ -73,8 +73,7 @@ func (m *Memory) Set32(offset uint64, val *uint256.Int) {
                panic("invalid memory: store empty")
        }
        // Fill in relevant bits
-       b32 := val.Bytes32()
-       copy(m.store[offset:], b32[:])
+       val.WriteToArray32((*[32]byte)(m.store[offset:]))
 }
```
Benchmark result
```
goos: linux
goarch: amd64
pkg: github.com/ethereum/go-ethereum/core/vm
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
           │   old.txt    │               new.txt                │
           │    sec/op    │    sec/op     vs base                │
OpMstore-8   19.40n ± 27%   14.18n ± 17%  -26.91% (p=0.002 n=10)
```