### PR TITLE
add comment for the zero value of `Int`

### DIFF
--- a/uint256.go
+++ b/uint256.go
@@ -15,6 +15,7 @@ import (
 
 // Int is represented as an array of 4 uint64, in little-endian order,
 // so that Int[3] is the most significant, and Int[0] is the least significant
+// The zero value for an Int represents the value 0.
 type Int [4]uint64
 
 // NewInt returns a new initialized Int.


### PR DESCRIPTION
This PR make it explicit that the zero value of `uint256.Int` represents the value `0`, like `big.Int` [does](https://github.com/golang/go/blob/044ca4e5c878c785e2c69e5ebcb3d44bf97abc9f/src/math/big/int.go#L17).