### PR TITLE
conversion: faster Format for common verbs/flags

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -5,6 +5,8 @@
 package uint256
 
 import (
+	"fmt"
+	"io"
 	"math/big"
 	"math/rand"
 	"testing"
@@ -1137,4 +1139,22 @@ func BenchmarkSRsh(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = f2.SRsh(f2, 10)
 	}
+}
+
+func BenchmarkFormat(b *testing.B) {
+	benchmarkFormat := func(b *testing.B, format string, samples *[numSamples]Int) {
+		b.ReportAllocs()
+		for j := 0; j < b.N; j += numSamples {
+			for i := 0; i < numSamples; i++ {
+				fmt.Fprintf(io.Discard, format, &samples[i])
+			}
+		}
+	}
+	b.Run("%d/small", func(b *testing.B) { benchmarkFormat(b, "%d", &int64Samples) })
+	b.Run("%d/large", func(b *testing.B) { benchmarkFormat(b, "%d", &int256Samples) })
+	b.Run("%x/small", func(b *testing.B) { benchmarkFormat(b, "%x", &int64Samples) })
+	b.Run("%x/large", func(b *testing.B) { benchmarkFormat(b, "%x", &int256Samples) })
+	b.Run("%v/large", func(b *testing.B) { benchmarkFormat(b, "%v", &int256Samples) })
+	b.Run("%#x/large", func(b *testing.B) { benchmarkFormat(b, "%#x", &int256Samples) })
+	b.Run("%10d/large", func(b *testing.B) { benchmarkFormat(b, "%10d", &int256Samples) })
 }

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1146,7 +1146,7 @@ func BenchmarkFormat(b *testing.B) {
 		b.ReportAllocs()
 		for j := 0; j < b.N; j += numSamples {
 			for i := 0; i < numSamples; i++ {
-				fmt.Fprintf(io.Discard, format, &samples[i])
+				_, _ = fmt.Fprintf(io.Discard, format, &samples[i])
 			}
 		}
 	}

--- a/conversion.go
+++ b/conversion.go
@@ -292,6 +292,26 @@ func (z *Int) SetFromBig(b *big.Int) bool {
 // width, space or zero padding, and '-' for left or right
 // justification.
 func (z *Int) Format(s fmt.State, ch rune) {
+	if z == nil {
+		z.ToBig().Format(s, ch) // preserve "<nil>" behavior
+		return
+	}
+	// Fast path for common verbs without width/precision/flags:
+	// avoid allocating a big.Int via ToBig().
+	if _, hasWidth := s.Width(); !hasWidth {
+		if _, hasPrec := s.Precision(); !hasPrec {
+			if !s.Flag('+') && !s.Flag(' ') && !s.Flag('-') && !s.Flag('0') && !s.Flag('#') {
+				switch ch {
+				case 'd', 'v', 's':
+					s.Write([]byte(z.Dec()))
+					return
+				case 'x':
+					s.Write([]byte(z.Hex()[2:])) // Hex() always has "0x" prefix
+					return
+				}
+			}
+		}
+	}
 	z.ToBig().Format(s, ch)
 }
 

--- a/conversion.go
+++ b/conversion.go
@@ -303,10 +303,10 @@ func (z *Int) Format(s fmt.State, ch rune) {
 			if !s.Flag('+') && !s.Flag(' ') && !s.Flag('-') && !s.Flag('0') && !s.Flag('#') {
 				switch ch {
 				case 'd', 'v', 's':
-					s.Write([]byte(z.Dec()))
+					_, _ = s.Write([]byte(z.Dec()))
 					return
 				case 'x':
-					s.Write([]byte(z.Hex()[2:])) // Hex() always has "0x" prefix
+					_, _ = s.Write([]byte(z.Hex()[2:])) // Hex() always has "0x" prefix
 					return
 				}
 			}

--- a/conversion.go
+++ b/conversion.go
@@ -293,7 +293,7 @@ func (z *Int) SetFromBig(b *big.Int) bool {
 // justification.
 func (z *Int) Format(s fmt.State, ch rune) {
 	if z == nil {
-		z.ToBig().Format(s, ch) // preserve "<nil>" behavior
+		_, _ = fmt.Fprint(s, "<nil>")
 		return
 	}
 	// Fast path for common verbs without width/precision/flags:

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -395,6 +395,7 @@ func TestFormat(t *testing.T) {
 		"%#x", "%#X", "%#o", "%+d", "% d", "%10d", "%.5d", "%010x", "%-10d",
 	}
 	values := []*big.Int{
+		nil,
 		big.NewInt(0),
 		big.NewInt(1),
 		big.NewInt(255),

--- a/conversion_test.go
+++ b/conversion_test.go
@@ -389,6 +389,33 @@ func TestFormat(t *testing.T) {
 			t.Errorf("Invalid format conversion to hex: %s, expected %s", s, expected)
 		}
 	}
+
+	formats := []string{
+		"%d", "%v", "%s", "%x", "%X", "%b", "%o", "%O",
+		"%#x", "%#X", "%#o", "%+d", "% d", "%10d", "%.5d", "%010x", "%-10d",
+	}
+	values := []*big.Int{
+		big.NewInt(0),
+		big.NewInt(1),
+		big.NewInt(255),
+		new(big.Int).SetBytes(hex2Bytes("ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100")),
+	}
+	for _, bg := range values {
+		u, overflow := FromBig(bg)
+		if overflow {
+			t.Fatalf("overflow on %x", bg)
+		}
+		for _, format := range formats {
+			want := fmt.Sprintf(format, bg)
+			have := fmt.Sprintf(format, u)
+			if have != want {
+				t.Errorf("format %q value %x: have %q, want %q", format, bg, have, want)
+			}
+		}
+	}
+	if have, want := fmt.Sprintf("%v", (*Int)(nil)), "<nil>"; have != want {
+		t.Errorf("nil format: have %q, want %q", have, want)
+	}
 }
 
 // TestSetBytes tests all setbyte-methods from 0 to overlong,


### PR DESCRIPTION
## Summary
- Fast-path `(*Int).Format` for common verbs (`%d`, `%v`, `%s`, `%x`) when no width, precision, or format flags are set, using `Dec()` / `Hex()` instead of allocating via `ToBig()`.
- Fall back to `big.Int.Format` for all other cases (flags, width, precision, other verbs) to preserve full `fmt` compatibility, including nil `"<nil>"` behavior.
- Add `BenchmarkFormat` and expand `TestFormat` to compare against `big.Int` across verbs and flags.

## Benchmark (Apple M4, benchstat n=6)

```
name                 old time/op    new time/op    delta
Format/%d/small-10     162ns ± 3%      66ns ± 8%  -59.36%
Format/%d/large-10     267ns ± 1%     212ns ± 4%  -20.42%
Format/%x/small-10     123ns ± 4%      59ns ± 1%  -52.21%
Format/%x/large-10     138ns ± 5%      78ns ± 0%  -43.63%
Format/%v/large-10     273ns ± 4%     214ns ± 0%  -21.60%
Format/%#x/large-10    148ns ± 3%     158ns ± 1%   +6.51%  (fallback)
Format/%10d/large-10   279ns ± 1%     281ns ± 1%   +0.75%  (fallback)
geomean                188ns          129ns       -31.16%

name                 old allocs/op  new allocs/op  delta
Format/%d/small-10     6.00 ± 0%      2.00 ± 0%  -66.67%
Format/%d/large-10     7.00 ± 0%      2.00 ± 0%  -71.43%
Format/%x/small-10     6.00 ± 0%      2.00 ± 0%  -66.67%
Format/%x/large-10     6.00 ± 0%      2.00 ± 0%  -66.67%
Format/%v/large-10     7.00 ± 0%      2.00 ± 0%  -71.43%
geomean                6.55           2.86       -56.34%
```

## Test plan
- [x] `go test -run=TestFormat`
- [x] `go test -bench=BenchmarkFormat -benchmem -count=6` (before/after via benchstat)
- [ ] CI passes on the PR